### PR TITLE
Automatically assign author to events created by plugin

### DIFF
--- a/core.traktivity.php
+++ b/core.traktivity.php
@@ -498,7 +498,7 @@ class Traktivity_Calls {
 						'role'    => 'administrator',
 						'orderby' => 'user_registered',
 						'order'   => 'ASC',
-						'fields'  => array( 'ID' ),
+						'fields'  => 'ID',
 						'number'  => 1,
 					)
 				);
@@ -513,7 +513,7 @@ class Traktivity_Calls {
 					'meta_input'   => $meta,
 					'post_content' => esc_html( $post_content ),
 					'post_excerpt' => esc_html( $post_excerpt ),
-					'post_author'  => ( ! empty( $first_admin ) ? (int) $first_admin[0]->ID : 0 )
+					'post_author'  => ( ! empty( $first_admin ) ? (int) $first_admin[0] : 0 )
 				);
 
 				// Create our post.

--- a/core.traktivity.php
+++ b/core.traktivity.php
@@ -502,6 +502,14 @@ class Traktivity_Calls {
 						'number'  => 1,
 					)
 				);
+				/**
+				 * Allow third-parties to provide their own author to be used.
+				 *
+				 * @since 2.3.1
+				 *
+				 * @param array $first_admin Array of user IDs, e.g. [ "1" ].
+				 */
+				$first_admin = apply_filters( 'traktivity_event_author', $first_admin );
 
 				// Let it all come together as a list of things we'll add to the post we're creating.
 				$event_args = array(

--- a/core.traktivity.php
+++ b/core.traktivity.php
@@ -490,6 +490,19 @@ class Traktivity_Calls {
 				 */
 				$title = apply_filters( 'traktivity_event_title', $title, $event );
 
+				/**
+				 * Get the first registered admin.
+				 */
+				$first_admin = get_users(
+					array(
+						'role'    => 'administrator',
+						'orderby' => 'user_registered',
+						'order'   => 'ASC',
+						'fields'  => array( 'ID' ),
+						'number'  => 1,
+					)
+				);
+
 				// Let it all come together as a list of things we'll add to the post we're creating.
 				$event_args = array(
 					'post_title'   => esc_html( $title ),
@@ -500,6 +513,7 @@ class Traktivity_Calls {
 					'meta_input'   => $meta,
 					'post_content' => esc_html( $post_content ),
 					'post_excerpt' => esc_html( $post_excerpt ),
+					'post_author'  => ( ! empty( $first_admin ) ? (int) $first_admin[0]->ID : 0 )
 				);
 
 				// Create our post.

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Traktivity ===
 Contributors: jeherve
 Tags: Trakt.tv, TV, Activity, Track, tmdb, Movies, TV Shows, Trakt, Log
-Stable tag: 2.3.0
+Stable tag: 2.3.1
 Requires at least: 5.1
-Tested up to: 5.5
+Tested up to: 5.7
 License: GPLv2+
 
 Are you a TV addict, and want to keep track of all the shows you've binge-watched and movies you saw? Traktivity is for you!
@@ -50,6 +50,11 @@ Do you like that header image? Me too! Credit goes to [Andrew Branch](https://un
 6. Movie: example of a movie and some of the details logged for that movie.
 
 == Changelog ==
+
+= 2.3.1 =
+Release Date: March 31, 2021
+
+* Automatically add an author (first registered admin) to events created by the plugin.
 
 = 2.3.0 =
 Release Date: September 21, 2020

--- a/traktivity.php
+++ b/traktivity.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://wordpress.org/plugins/traktivity
  * Description: Log your activity on Trakt.tv
  * Author: Jeremy Herve
- * Version: 2.3.0
+ * Version: 2.3.1
  * Author URI: https://jeremy.hu
  * License: GPL2+
  * Text Domain: traktivity
@@ -15,7 +15,7 @@
 
 defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
 
-define( 'TRAKTIVITY__VERSION',          '2.3.0' );
+define( 'TRAKTIVITY__VERSION',          '2.3.1' );
 define( 'TRAKTIVITY__API_URL',          'https://api.trakt.tv' );
 define( 'TRAKTIVITY__API_VERSION',      '2' );
 define( 'TRAKTIVITY__TMDB_API_URL',     'https://api.themoviedb.org' );


### PR DESCRIPTION

### In this PR

﻿- Add author to traktivity events
- Up version and create readme
- Return less info since we don't need the full WP_USER with just ID
- Add filter for folks willing to filter to their own choice.
