### PR TITLE
Accept API keys and usernames containing underscores

### DIFF
--- a/admin/components/Setup.js
+++ b/admin/components/Setup.js
@@ -221,7 +221,7 @@ class Setup extends React.Component {
 				'X-WP-Nonce': traktivity_dash.api_nonce
 			},
 		};
-		const checkCredsPromise = fetch( `${traktivity_dash.api_url}traktivity/v1/connection/${username}/${key}`, fetchOptions );
+		const checkCredsPromise = fetch( `${traktivity_dash.api_url}traktivity/v1/connection/${encodeURIComponent(username)}/${encodeURIComponent(key)}`, fetchOptions );
 		return checkCredsPromise
 			.then((response) => response.json())
 			.then((body) => {
@@ -259,7 +259,7 @@ class Setup extends React.Component {
 				'X-WP-Nonce': traktivity_dash.api_nonce
 			},
 		};
-		const checkCredsPromise = fetch( `${traktivity_dash.api_url}traktivity/v1/tmdb/${key}`, fetchOptions );
+		const checkCredsPromise = fetch( `${traktivity_dash.api_url}traktivity/v1/tmdb/${encodeURIComponent(key)}`, fetchOptions );
 		return checkCredsPromise
 			.then((response) => response.json())
 			.then((body) => {

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Traktivity ===
 Contributors: jeherve
 Tags: Trakt.tv, TV, Activity, Track, tmdb, Movies, TV Shows, Trakt, Log
-Stable tag: 2.3.5
+Stable tag: 2.3.6
 Requires at least: 5.1
 Tested up to: 6.2
 License: GPLv2+
@@ -50,6 +50,11 @@ Do you like that header image? Me too! Credit goes to [Andrew Branch](https://un
 6. Movie: example of a movie and some of the details logged for that movie.
 
 == Changelog ==
+
+= 2.3.6 =
+Release date: August 31, 2026
+
+* Allow underscores and other characters in Trakt.tv and TMDb API keys, as well as in Trakt.tv usernames.
 
 = 2.3.5 =
 Release date: April 24, 2023

--- a/rest.traktivity.php
+++ b/rest.traktivity.php
@@ -56,7 +56,7 @@ class Traktivity_Api {
 		 *
 		 * @since 1.1.0
 		 */
-		register_rest_route( 'traktivity/v1', '/connection/(?P<user>[a-z0-9\-\.]+)/(?P<trakt>[a-zA-Z0-9-]+)', array(
+		register_rest_route( 'traktivity/v1', '/connection/(?P<user>[^/]+)/(?P<trakt>[^/]+)', array(
 			'methods'             => WP_REST_Server::READABLE,
 			'callback'            => array( $this, 'test_trakt_api_connection' ),
 			'permission_callback' => array( $this, 'permissions_check' ),
@@ -77,7 +77,7 @@ class Traktivity_Api {
 		 *
 		 * @since 2.0.0
 		 */
-		register_rest_route( 'traktivity/v1', '/tmdb/(?P<tmdb>[a-zA-Z0-9-]+)', array(
+		register_rest_route( 'traktivity/v1', '/tmdb/(?P<tmdb>[^/]+)', array(
 			'methods'             => WP_REST_Server::READABLE,
 			'callback'            => array( $this, 'test_tmdb_api_connection' ),
 			'permission_callback' => array( $this, 'permissions_check' ),
@@ -137,7 +137,12 @@ class Traktivity_Api {
 	 * @return bool $validated Is the API key in a valid format.
 	 */
 	public function validate_string( $param, $request, $key ) {
-		return is_string( $param );
+		// Usernames and API keys are single opaque tokens: never empty, never whitespace or control characters.
+		return (
+			is_string( $param )
+			&& '' !== $param
+			&& ! preg_match( '/[\s\x00-\x1F\x7F]/', $param )
+		);
 	}
 
 	/**
@@ -170,12 +175,12 @@ class Traktivity_Api {
 		$headers = array(
 			'Content-Type'      => 'application/json',
 			'trakt-api-version' => TRAKTIVITY__API_VERSION,
-			'trakt-api-key'     => esc_html( $trakt ),
+			'trakt-api-key'     => $trakt,
 		);
 		$query_url = sprintf(
 			'%1$s/users/%2$s/history?limit=1',
 			TRAKTIVITY__API_URL,
-			esc_html( $user )
+			rawurlencode( $user )
 		);
 		$data = wp_remote_get(
 			esc_url_raw( $query_url ),
@@ -257,7 +262,7 @@ class Traktivity_Api {
 			TRAKTIVITY__TMDB_API_URL,
 			TRAKTIVITY__TMDB_API_VERSION,
 			'discover/movie',
-			esc_attr( $request['tmdb'] )
+			rawurlencode( $request['tmdb'] )
 		);
 		$data = wp_remote_get( esc_url_raw( $query_url ) );
 

--- a/traktivity.php
+++ b/traktivity.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://wordpress.org/plugins/traktivity
  * Description: Log your activity on Trakt.tv
  * Author: Jeremy Herve
- * Version: 2.3.5
+ * Version: 2.3.6
  * Author URI: https://jeremy.hu
  * License: GPL2+
  * Text Domain: traktivity
@@ -15,7 +15,7 @@
 
 defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
 
-define( 'TRAKTIVITY__VERSION',          '2.3.5' );
+define( 'TRAKTIVITY__VERSION',          '2.3.6' );
 define( 'TRAKTIVITY__API_URL',          'https://api.trakt.tv' );
 define( 'TRAKTIVITY__API_VERSION',      '2' );
 define( 'TRAKTIVITY__TMDB_API_URL',     'https://api.themoviedb.org' );


### PR DESCRIPTION
## What it does

The `/connection` and `/tmdb` REST routes used their URL regex as an input validator; the key segment only allowed `[a-zA-Z0-9-]`. A Trakt.tv API key with an underscore in it never matched the route, so WordPress never reached the permission or validation callbacks and answered `rest_no_route` with a 404.

From the dashboard that looks like a broken install rather than a rejected value. You get "No route was found matching the URL and request method", with nothing pointing at the key.

Both token segments now accept `[^/]+`, and the validation moves into `validate_string`, which rejects empty values, whitespace and control characters. A key that really is unusable comes back as a 400 naming the parameter.

## Rationale

This is the second time the route alphabet has been too narrow. 2.3.4 widened it for periods in usernames, after [a support report](https://wordpress.org/support/topic/no-route-was-found-matching-the-url-and-request-method-12/#post-15806355) with the same symptom. Adding underscores too would just line up the next report; Trakt and TMDb own these token formats, and we don't get a say in them.

So the route stops trying to validate. That isn't a loosening: `permission_callback` still requires `manage_options`, the host is fixed by `TRAKTIVITY__API_URL`, and `/` stays excluded, so there's no way to point the outbound request somewhere else.

Widening the segments does mean the values aren't guaranteed alphanumeric any more, so the escaping had to be corrected alongside it. `esc_html()` and `esc_attr()` were being used to build an HTTP header value and URL path and query segments. HTML escaping turns an `&` into `&amp;`, which would have quietly queried the wrong user. The header now gets the validated raw value, the URL segments use `rawurlencode()`, and the dashboard encodes both segments before they go in the path.

Small caveat: a pasted key with trailing whitespace is now a clear 400 rather than being silently trimmed. Trimming in `saveCreds` would be friendlier, but that's a separate change.

## Testing instructions

Unauthenticated against the route, a match gives `rest_forbidden` (401) and a non-match gives `rest_no_route` (404):

```bash
KEY=$(python3 -c "import secrets;print(secrets.token_hex(32))")

# Matched before this change, still matches: 401.
curl -s "https://example.com/wp-json/traktivity/v1/connection/jeherve/$KEY"

# 404 rest_no_route before, 401 after.
curl -s "https://example.com/wp-json/traktivity/v1/connection/jeherve/${KEY:0:20}_${KEY:21}"
```

Then in Trakt.tv Events -> Traktivity, enter a username and an API key containing an underscore. Before, the connection check failed with "No route was found matching the URL and request method". After, it reaches Trakt.tv and tells you whether the key works.

Of note, the `Setup.js` change needs `npm run build` to reach a site; the PHP fix works on its own. And there's no test suite in the repo, so the checks above are manual. :)

https://claude.ai/code/session_01CbuQvK7gCV6LBWUwCQxtp4
