### PR TITLE
Move the workflow actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           coverage: none
           tools: composer
 
-      - uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # 3.2.1
+      - uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
 
       - name: Coding standards
         run: composer run lint
@@ -85,7 +85,7 @@ jobs:
 
       # PHPUnit runs inside the container, against the vendor directory
       # mounted with the plugin.
-      - uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # 3.2.1
+      - uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
 
       # wp-env serves the plugin directory as-is, so the bundle has to exist.
       - name: Build
@@ -105,7 +105,7 @@ jobs:
 
       - name: Upload failure artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-artifacts
           path: artifacts/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,6 +71,6 @@ jobs:
 
       - name: Attach the archive to the release
         if: github.event_name == 'release'
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           files: ${{ steps.deploy.outputs.zip-path }}


### PR DESCRIPTION
## What it does

The 3.0.0 deploy went through fine, but left this in the log:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65

GitHub is doing that forcing for now, and won't forever. Three actions move to versions that target Node 24 on their own:

- `softprops/action-gh-release` 2.6.2 to 3.0.3, the one named in the warning.
- `actions/upload-artifact` v4 to v7. Same problem, in `ci.yml` rather than `deploy.yml`, so it only shows up on the failure path where that step runs at all.
- `ramsey/composer-install` 3.2.1 to 4.0.0. It's a composite action, so it never warns on its own account; it wraps `actions/cache` though, and 4.0.0 is the release that carries cache v5.

`shivammathur/setup-php` was already pinned at 2.37.2, and the 10up deploy action is shell only with nothing nested inside it, so neither needed touching.

## Rationale

All three majors exist for the runtime bump and not much else. `action-gh-release` 3.0.0 says so in its own release notes, and leaves the `files` input alone. `upload-artifact` v6 is the Node 24 release; v7 adds an `archive` input that defaults to the old behaviour. `composer-install` 4.0.0 is a single Dependabot commit bumping `actions/cache`, with inputs identical to 3.2.1's, down to `dependency-versions` being nominally required in both while the workflow leans on its default.

`upload-artifact` goes to v7 rather than v6 because there's no reason to stop one major short. That does leave `actions/checkout` and `actions/setup-node` on v5 with v7 out, which is uneven, but both are already on Node 24, so I left those to Renovate.

The comments now name the exact release instead of the major. A pin commented `# v2` is how this one sat on the last Node 20 build without me noticing :)

## Testing

CI runs `composer-install` on both PHP jobs, so a green build covers that one. `upload-artifact` only fires when the e2e job fails, and `action-gh-release` only runs on a published release, so neither gets exercised here.

The pins do resolve to what the comments claim:

```sh
gh api repos/softprops/action-gh-release/commits/efb35369e0ad2afab669f228072c1b0d510eae64 --jq '.commit.message'
# release 3.0.3 (#840)

gh api repos/ramsey/composer-install/commits/65e4f84970763564f46a70b8a54b90d033b3bdda --jq '.commit.message'
# docs: update badges for v4 branch
```

And every action in both workflows now reports `node24` or `composite`, none `node20`.
