### PR TITLE
Sync the whole Trakt.tv history, not just the newest tenth

### DIFF
--- a/core.traktivity.php
+++ b/core.traktivity.php
@@ -51,6 +51,21 @@ class Traktivity_Calls {
 	private const SYNC_PAGES_PER_RUN = 10;
 
 	/**
+	 * Times in a row a full sync will ask again after a request it could not
+	 * read, before it gives up and waits to be started by hand.
+	 *
+	 * Every failed request arrives the same way, so a key that has been revoked
+	 * or a username that no longer exists is indistinguishable from a timeout.
+	 * Without a ceiling, the one that is never going to succeed would have the
+	 * site asking Trakt.tv once a minute for as long as it stayed wrong.
+	 *
+	 * @since 3.0.1
+	 *
+	 * @var int
+	 */
+	private const SYNC_MAX_ATTEMPTS = 5;
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
@@ -179,7 +194,19 @@ class Traktivity_Calls {
 		}
 
 		if ( true === $test ) {
-			return (int) wp_remote_retrieve_header( $data, 'X-Pagination-Page-Count' );
+			$page_count = wp_remote_retrieve_header( $data, 'X-Pagination-Page-Count' );
+
+			/*
+			 * Trakt.tv sends this on every paginated response. Without it there
+			 * is no telling an account with nothing watched from a response we
+			 * cannot make sense of, and reading it as zero would end a sync as
+			 * complete with the history still sitting on Trakt.tv.
+			 */
+			if ( ! is_numeric( $page_count ) ) {
+				return null;
+			}
+
+			return (int) $page_count;
 		}
 
 		$response_body = json_decode( $data['body'] );
@@ -945,6 +972,30 @@ class Traktivity_Calls {
 	}
 
 	/**
+	 * Record a request we could not read, and ask again unless this has been
+	 * going on long enough to look permanent.
+	 *
+	 * @since 3.0.1
+	 *
+	 * @param int $failures Requests already failed in a row before this one.
+	 */
+	private function note_failure_and_retry( $failures ) {
+		$failures = (int) $failures + 1;
+
+		$this->update_sync_status( array( 'failures' => $failures ) );
+
+		/*
+		 * Out of attempts. Leave the status where it is so the dashboard can
+		 * start the sync again, and stop asking in the meantime.
+		 */
+		if ( $failures >= self::SYNC_MAX_ATTEMPTS ) {
+			return;
+		}
+
+		$this->schedule_next_run();
+	}
+
+	/**
 	 * Get all past Trakt.tv events from all Trakt.tv pages.
 	 *
 	 * @since 1.1.0
@@ -974,6 +1025,8 @@ class Traktivity_Calls {
 			return;
 		}
 
+		$failures = isset( $status['failures'] ) ? (int) $status['failures'] : 0;
+
 		/**
 		 * If we have no page count yet, that means we never ran sync before.
 		 * Let's get started by changing the status to 'in_progress', and get some data.
@@ -989,7 +1042,7 @@ class Traktivity_Calls {
 			 * nothing to resume from either.
 			 */
 			if ( null === $pages ) {
-				$this->schedule_next_run();
+				$this->note_failure_and_retry( $failures );
 
 				return;
 			}
@@ -1018,8 +1071,9 @@ class Traktivity_Calls {
 			// Update our option.
 			$this->update_sync_status(
 				array(
-					'status' => 'in_progress',
-					'pages'  => $pages,
+					'status'   => 'in_progress',
+					'pages'    => $pages,
+					'failures' => 0,
 				)
 			);
 		}
@@ -1046,7 +1100,7 @@ class Traktivity_Calls {
 			 * report itself done.
 			 */
 			if ( ! $fetched ) {
-				$this->schedule_next_run();
+				$this->note_failure_and_retry( $failures );
 
 				return;
 			}
@@ -1057,7 +1111,14 @@ class Traktivity_Calls {
 			 * does not reach the end throws away everything it fetched, and the
 			 * next one starts the history over.
 			 */
-			$this->update_sync_status( array( 'pages' => $page - 1 ) );
+			$this->update_sync_status(
+				array(
+					'pages'    => $page - 1,
+					'failures' => 0,
+				)
+			);
+
+			$failures = 0;
 
 			// Enough for this run. Queue the next one to pick up the rest.
 			if ( ++$processed >= self::SYNC_PAGES_PER_RUN && $page > 1 ) {

--- a/core.traktivity.php
+++ b/core.traktivity.php
@@ -25,7 +25,9 @@ class Traktivity_Calls {
 	 * at another means the count describes pages we never fetch, and the sync
 	 * quietly imports a fraction of the history.
 	 *
-	 * 100 is Trakt.tv's own default, and its maximum.
+	 * 100 is what Trakt.tv falls back to when a request leaves the page size
+	 * out. Their maximum is 250, and a larger limit is silently clamped to it
+	 * rather than refused, so asking for more would not buy anything.
 	 *
 	 * @since 3.0.1
 	 *

--- a/core.traktivity.php
+++ b/core.traktivity.php
@@ -66,6 +66,21 @@ class Traktivity_Calls {
 	private const SYNC_MAX_ATTEMPTS = 5;
 
 	/**
+	 * How long a sync can go without recording progress before the hourly
+	 * check treats it as stalled and puts it back on the schedule.
+	 *
+	 * WordPress clears a single event before running its callback, so a run
+	 * that dies part way through, on a fatal error or a worker being cut off,
+	 * leaves a sync in progress with nothing queued to carry it on. Long enough
+	 * that a run still working is never mistaken for a dead one.
+	 *
+	 * @since 3.0.1
+	 *
+	 * @var int
+	 */
+	private const SYNC_STALLED_AFTER = 15 * MINUTE_IN_SECONDS;
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
@@ -763,6 +778,42 @@ class Traktivity_Calls {
 	 */
 	public function publish_latest_events() {
 		$this->publish_event();
+
+		$this->resume_a_stalled_sync();
+	}
+
+	/**
+	 * Put a sync that stopped without finishing back on the schedule.
+	 *
+	 * A run cut off part way through leaves its progress recorded but nothing
+	 * queued to carry on from it, and the dashboard only picks one up when
+	 * somebody opens it. Ride along with the hourly check for new events so a
+	 * sync gets going again on its own.
+	 *
+	 * @since 3.0.1
+	 */
+	private function resume_a_stalled_sync() {
+		$status = $this->get_option( 'full_sync' );
+
+		if (
+			! is_array( $status )
+			|| ! isset( $status['status'] )
+			|| 'in_progress' !== $status['status']
+		) {
+			return;
+		}
+
+		/*
+		 * Still making progress, so there is a run working through the history
+		 * right now and a second one would only duplicate its requests.
+		 */
+		$updated = isset( $status['updated'] ) ? (int) $status['updated'] : 0;
+
+		if ( $updated > time() - self::SYNC_STALLED_AFTER ) {
+			return;
+		}
+
+		$this->schedule_next_run();
 	}
 
 	/**
@@ -1074,8 +1125,12 @@ class Traktivity_Calls {
 					'status'   => 'in_progress',
 					'pages'    => $pages,
 					'failures' => 0,
+					'updated'  => time(),
 				)
 			);
+
+			// That request worked, so whatever failed before it is behind us.
+			$failures = 0;
 		}
 
 		// Set WP_IMPORTING to avoid triggering things like subscription emails.
@@ -1115,6 +1170,7 @@ class Traktivity_Calls {
 				array(
 					'pages'    => $page - 1,
 					'failures' => 0,
+					'updated'  => time(),
 				)
 			);
 

--- a/core.traktivity.php
+++ b/core.traktivity.php
@@ -34,6 +34,21 @@ class Traktivity_Calls {
 	private const SYNC_PAGE_SIZE = 100;
 
 	/**
+	 * Number of pages a single full sync run works through before handing off
+	 * to the next one.
+	 *
+	 * A large history takes far longer than any one request is allowed to live,
+	 * and every event costs a themoviedb.org lookup on top of the post insert.
+	 * Stopping at a batch boundary and queueing the next run keeps each run
+	 * short enough to finish.
+	 *
+	 * @since 3.0.1
+	 *
+	 * @var int
+	 */
+	private const SYNC_PAGES_PER_RUN = 10;
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
@@ -925,6 +940,8 @@ class Traktivity_Calls {
 		defined( 'WP_IMPORTING' ) || define( 'WP_IMPORTING', true );
 
 		// let's start looping, from the last page back to the first.
+		$processed = 0;
+
 		for ( $page = (int) $status['pages']; $page > 0; $page-- ) {
 			$this->publish_event(
 				array(
@@ -932,6 +949,24 @@ class Traktivity_Calls {
 					'limit' => self::SYNC_PAGE_SIZE,
 				)
 			);
+
+			/*
+			 * Record what is left after every page. This runs on cron and can
+			 * be cut short at any point, so without saving as we go a run that
+			 * does not reach the end throws away everything it fetched, and the
+			 * next one starts the history over.
+			 */
+			$status['pages'] = $page - 1;
+			$this->update_option( 'full_sync', $status );
+
+			// Enough for this run. Queue the next one to pick up the rest.
+			if ( ++$processed >= self::SYNC_PAGES_PER_RUN && $page > 1 ) {
+				if ( ! wp_next_scheduled( 'traktivity_full_sync' ) ) {
+					wp_schedule_single_event( time() + MINUTE_IN_SECONDS, 'traktivity_full_sync' );
+				}
+
+				return;
+			}
 		}
 
 		// We're done. Save options.

--- a/core.traktivity.php
+++ b/core.traktivity.php
@@ -55,7 +55,7 @@ class Traktivity_Calls {
 	 */
 	public function __construct() {
 		// Check for new events and publish them every hour.
-		add_action( 'traktivity_publish', array( $this, 'publish_event' ) );
+		add_action( 'traktivity_publish', array( $this, 'publish_latest_events' ) );
 		if ( ! wp_next_scheduled( 'traktivity_publish' ) ) {
 			wp_schedule_event( time(), 'hourly', 'traktivity_publish' );
 		}
@@ -427,6 +427,10 @@ class Traktivity_Calls {
 	 *  @int int page  Number of page of results to be returned. Accepts integers.
 	 *  @int int limit Number of results to return per page. Accepts integers.
 	 * }
+	 *
+	 * @return bool Whether Trakt.tv returned a page of events. False means the
+	 *              request failed and nothing was read, which a caller walking
+	 *              the history has to tell apart from a page that held nothing.
 	 */
 	public function publish_event( $args = array() ) {
 		// Avoid timeouts during the data import process.
@@ -434,10 +438,16 @@ class Traktivity_Calls {
 
 		$trakt_events = $this->get_trakt_activity( $args, false );
 
+		/*
+		 * Whether Trakt.tv answered with a page at all. A caller walking the
+		 * history needs to tell that apart from a page that held no events.
+		 */
+		$fetched = is_array( $trakt_events );
+
 		/**
 		 * Only go through the event list if we have valid event array.
 		 */
-		if ( isset( $trakt_events ) && is_array( $trakt_events ) ) {
+		if ( $fetched ) {
 			foreach ( $trakt_events as $event ) {
 				// Avoid errors when no type is attached to the event.
 				if ( ! isset( $event->type ) ) {
@@ -710,6 +720,22 @@ class Traktivity_Calls {
 				} // End loop for each taxonomy that was created.
 			} // End loop for each event.
 		} // End check for valid array of events.
+
+		return $fetched;
+	}
+
+	/**
+	 * Look for new events on the hourly schedule.
+	 *
+	 * Whether Trakt.tv answered is reported by publish_event(), and an action
+	 * callback is not supposed to return anything, so the hook comes here.
+	 *
+	 * @since 3.0.1
+	 *
+	 * @return void This is an action callback; WordPress discards any return value.
+	 */
+	public function publish_latest_events() {
+		$this->publish_event();
 	}
 
 	/**
@@ -881,6 +907,17 @@ class Traktivity_Calls {
 	}
 
 	/**
+	 * Queue the run that carries on from where this one stopped.
+	 *
+	 * @since 3.0.1
+	 */
+	private function schedule_next_run() {
+		if ( ! wp_next_scheduled( 'traktivity_full_sync' ) ) {
+			wp_schedule_single_event( time() + MINUTE_IN_SECONDS, 'traktivity_full_sync' );
+		}
+	}
+
+	/**
 	 * Get all past Trakt.tv events from all Trakt.tv pages.
 	 *
 	 * @since 1.1.0
@@ -915,18 +952,29 @@ class Traktivity_Calls {
 		 * Let's get started by changing the status to 'in_progress', and get some data.
 		 */
 		if ( ! isset( $status['pages'] ) ) {
-			$pages = (int) $this->get_trakt_activity( array( 'limit' => self::SYNC_PAGE_SIZE ), true );
+			$pages = $this->get_trakt_activity( array( 'limit' => self::SYNC_PAGE_SIZE ), true );
 
 			/*
-			 * Trakt.tv reports how many pages of history there are, and the loop
-			 * below counts that number down. A failed request reports nothing,
-			 * and a count of zero counts down without ever reaching zero again.
-			 *
-			 * Stop without saving anything, so the next run asks Trakt.tv for
-			 * the count again rather than being left in progress with no pages
-			 * to fetch.
+			 * The request failed. Save nothing, so the next run asks Trakt.tv
+			 * for the count again rather than sitting in progress with no
+			 * pages to fetch.
+			 */
+			if ( null === $pages ) {
+				return;
+			}
+
+			$pages = (int) $pages;
+
+			/*
+			 * An account with nothing watched yet reports no pages. There is
+			 * nothing to walk, so record the sync as finished instead of
+			 * asking again on every run for a history that does not exist.
 			 */
 			if ( $pages < 1 ) {
+				$status['status'] = 'done';
+				$status['pages']  = 0;
+				$this->update_option( 'full_sync', $status );
+
 				return;
 			}
 
@@ -945,12 +993,24 @@ class Traktivity_Calls {
 		$processed = 0;
 
 		for ( $page = (int) $status['pages']; $page > 0; $page-- ) {
-			$this->publish_event(
+			$fetched = $this->publish_event(
 				array(
 					'page'  => $page,
 					'limit' => self::SYNC_PAGE_SIZE,
 				)
 			);
+
+			/*
+			 * Trakt.tv did not hand that page over, so leave the count where it
+			 * is and come back to the same page. Stepping over it would drop up
+			 * to a page of events for good, and the sync would still finish and
+			 * report itself done.
+			 */
+			if ( ! $fetched ) {
+				$this->schedule_next_run();
+
+				return;
+			}
 
 			/*
 			 * Record what is left after every page. This runs on cron and can
@@ -963,9 +1023,7 @@ class Traktivity_Calls {
 
 			// Enough for this run. Queue the next one to pick up the rest.
 			if ( ++$processed >= self::SYNC_PAGES_PER_RUN && $page > 1 ) {
-				if ( ! wp_next_scheduled( 'traktivity_full_sync' ) ) {
-					wp_schedule_single_event( time() + MINUTE_IN_SECONDS, 'traktivity_full_sync' );
-				}
+				$this->schedule_next_run();
 
 				return;
 			}

--- a/core.traktivity.php
+++ b/core.traktivity.php
@@ -17,6 +17,23 @@ defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
 class Traktivity_Calls {
 
 	/**
+	 * Number of events requested per page during a full sync.
+	 *
+	 * Trakt.tv reports how many pages of history exist for the page size the
+	 * request asked for, so the page count and the pages we then walk have to
+	 * use this same value. Asking for the count at one size and walking pages
+	 * at another means the count describes pages we never fetch, and the sync
+	 * quietly imports a fraction of the history.
+	 *
+	 * 100 is Trakt.tv's own default, and its maximum.
+	 *
+	 * @since 3.0.1
+	 *
+	 * @var int
+	 */
+	private const SYNC_PAGE_SIZE = 100;
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
@@ -881,7 +898,7 @@ class Traktivity_Calls {
 		 * Let's get started by changing the status to 'in_progress', and get some data.
 		 */
 		if ( ! isset( $status['pages'] ) ) {
-			$pages = (int) $this->get_trakt_activity( array(), true );
+			$pages = (int) $this->get_trakt_activity( array( 'limit' => self::SYNC_PAGE_SIZE ), true );
 
 			/*
 			 * Trakt.tv reports how many pages of history there are, and the loop
@@ -912,7 +929,7 @@ class Traktivity_Calls {
 			$this->publish_event(
 				array(
 					'page'  => $page,
-					'limit' => 10,
+					'limit' => self::SYNC_PAGE_SIZE,
 				)
 			);
 		}

--- a/core.traktivity.php
+++ b/core.traktivity.php
@@ -899,11 +899,38 @@ class Traktivity_Calls {
 		}
 
 		// We're done. Save options.
-		$status['runtime'] = array(
-			'status' => 'done',
-			'items'  => 0,
+		$this->update_sync_status(
+			array(
+				'runtime' => array(
+					'status' => 'done',
+					'items'  => 0,
+				),
+			)
 		);
-		$this->update_option( 'full_sync', $status );
+	}
+
+	/**
+	 * Change some of the stored synchronization status, leaving the rest.
+	 *
+	 * The history sync and the recalculation of each show's total runtime both
+	 * keep their state in the 'full_sync' option, and each runs on its own cron
+	 * event, so the two can overlap. Writing back a copy of the option taken at
+	 * the start of a run would put back whatever the other job had recorded
+	 * since, rolling its progress backwards or dropping its completion. Read
+	 * the option again and change only the fields the caller owns.
+	 *
+	 * @since 3.0.1
+	 *
+	 * @param array $fields Status fields to set.
+	 */
+	private function update_sync_status( $fields ) {
+		$status = $this->get_option( 'full_sync' );
+
+		if ( ! is_array( $status ) ) {
+			$status = array();
+		}
+
+		$this->update_option( 'full_sync', array_merge( $status, $fields ) );
 	}
 
 	/**
@@ -957,9 +984,13 @@ class Traktivity_Calls {
 			/*
 			 * The request failed. Save nothing, so the next run asks Trakt.tv
 			 * for the count again rather than sitting in progress with no
-			 * pages to fetch.
+			 * pages to fetch, and queue that run: this one came from a
+			 * single cron event, and with no status saved the dashboard has
+			 * nothing to resume from either.
 			 */
 			if ( null === $pages ) {
+				$this->schedule_next_run();
+
 				return;
 			}
 
@@ -971,18 +1002,26 @@ class Traktivity_Calls {
 			 * asking again on every run for a history that does not exist.
 			 */
 			if ( $pages < 1 ) {
-				$status['status'] = 'done';
-				$status['pages']  = 0;
-				$this->update_option( 'full_sync', $status );
+				$this->update_sync_status(
+					array(
+						'status' => 'done',
+						'pages'  => 0,
+					)
+				);
 
 				return;
 			}
 
-			$status['status'] = 'in_progress';
-			$status['pages']  = $pages;
+			// Where the loop below starts from on this first run.
+			$status['pages'] = $pages;
 
 			// Update our option.
-			$this->update_option( 'full_sync', $status );
+			$this->update_sync_status(
+				array(
+					'status' => 'in_progress',
+					'pages'  => $pages,
+				)
+			);
 		}
 
 		// Set WP_IMPORTING to avoid triggering things like subscription emails.
@@ -1018,8 +1057,7 @@ class Traktivity_Calls {
 			 * does not reach the end throws away everything it fetched, and the
 			 * next one starts the history over.
 			 */
-			$status['pages'] = $page - 1;
-			$this->update_option( 'full_sync', $status );
+			$this->update_sync_status( array( 'pages' => $page - 1 ) );
 
 			// Enough for this run. Queue the next one to pick up the rest.
 			if ( ++$processed >= self::SYNC_PAGES_PER_RUN && $page > 1 ) {
@@ -1030,9 +1068,12 @@ class Traktivity_Calls {
 		}
 
 		// We're done. Save options.
-		$status['status'] = 'done';
-		$status['pages']  = 0;
-		$this->update_option( 'full_sync', $status );
+		$this->update_sync_status(
+			array(
+				'status' => 'done',
+				'pages'  => 0,
+			)
+		);
 	}
 }
 new Traktivity_Calls();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "traktivity",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "traktivity",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "GPL-2.0+",
       "devDependencies": {
         "@testing-library/jest-dom": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "traktivity",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Log your activity on Trakt.tv",
   "main": "traktivity.php",
   "files": [

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Traktivity ===
 Contributors: jeherve
 Tags: Trakt.tv, TV, Activity, Movies, Log
-Stable tag: 3.0.0
+Stable tag: 3.0.1
 Requires at least: 7.0
 Tested up to: 7.1
 Requires PHP: 7.4
@@ -70,6 +70,13 @@ There is more discussion in [issue #678](https://github.com/jeherve/traktivity/i
 Needs WordPress 7.0 and PHP 7.4.
 
 == Changelog ==
+
+= 3.0.1 =
+Release date: September 3, 2026
+
+* Fix a full synchronization importing only the most recent tenth of your Trakt.tv history before reporting itself complete. Trakt.tv is asked how many pages of history exist for a given page size, and Traktivity was asking at one size and then reading the pages at another.
+* Run a full synchronization in batches that pick up where the last one stopped, so a long history finishes instead of starting over whenever a run is cut short.
+* Existing sites can run a full synchronization again after updating, to bring in the events the earlier versions skipped. Events already imported are left alone.
 
 = 3.0.0 =
 Release date: September 2, 2026

--- a/readme.txt
+++ b/readme.txt
@@ -74,9 +74,9 @@ Needs WordPress 7.0 and PHP 7.4.
 = 3.0.1 =
 Release date: September 3, 2026
 
-* Fix a full synchronization importing only the most recent tenth of your Trakt.tv history before reporting itself complete. Trakt.tv is asked how many pages of history exist for a given page size, and Traktivity was asking at one size and then reading the pages at another.
-* Run a full synchronization in batches that pick up where the last one stopped, so a long history finishes instead of starting over whenever a run is cut short.
-* Existing sites can run a full synchronization again after updating, to bring in the events the earlier versions skipped. Events already imported are left alone.
+* Fix a full synchronization importing only the most recent tenth of your Trakt.tv history, after Trakt.tv changed their API to return 100 results per page by default instead of the documented 10.
+* Run a full synchronization in batches that resume, so a long history finishes instead of starting over when a run is cut short.
+* Let sites that already ran a full synchronization run one again after updating, to pick up the skipped events. Events already imported are left alone.
 
 = 3.0.0 =
 Release date: September 2, 2026

--- a/rest.traktivity.php
+++ b/rest.traktivity.php
@@ -369,6 +369,17 @@ class Traktivity_Api {
 			);
 		}
 
+		/*
+		 * Someone asking for a synchronization is a fresh start, so clear the
+		 * count of requests that failed in a row. A sync that gave up because
+		 * Trakt.tv kept refusing it would otherwise carry that tally into this
+		 * attempt and stop again on the first hiccup.
+		 */
+		if ( isset( $options['full_sync']['failures'] ) ) {
+			unset( $options['full_sync']['failures'] );
+			update_option( 'traktivity', $options );
+		}
+
 		// Return an error if Synchronization is currently in progress. Let's let it finish.
 		if (
 			isset( $options['full_sync'], $options['full_sync']['status'] )

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -10,6 +10,7 @@ import { __ } from '@wordpress/i18n';
  */
 import RecentEvents from './RecentEvents';
 import StatsOverview from './stats/StatsOverview';
+import SyncHistory from './SyncHistory';
 import SyncShowTime from './SyncShowTime';
 
 /**
@@ -21,14 +22,21 @@ import SyncShowTime from './SyncShowTime';
  * @return {Element} The dashboard.
  */
 export default function Dashboard( { sync, launchSync } ) {
-	const pagesLeft = sync.pages;
+	const historyImported = sync.status === 'done';
 
 	useEffect( () => {
 		/*
-		 * Pick a sync back up if it was interrupted with pages still to go.
-		 * A sync started from step 4 is kicked off there, not here.
+		 * Pick a sync back up if it was left part way through. A sync started
+		 * from step 4 is kicked off there, not here.
+		 *
+		 * This follows the recorded status rather than the pages left to go,
+		 * since a sync that stopped before it ever read a page count has none
+		 * recorded, and so does one whose stale status was cleared on update.
+		 * Both of those read as zero pages, which is also what a finished sync
+		 * reads as, so the count cannot tell them apart. Neither starts on its
+		 * own; the card below is how they get going again.
 		 */
-		if ( pagesLeft !== 0 ) {
+		if ( sync.status === 'in_progress' ) {
 			launchSync();
 		}
 		// Only ever run this on mount; launchSync is stable and re-running it
@@ -83,6 +91,12 @@ export default function Dashboard( { sync, launchSync } ) {
 			</Card>
 			<StatsOverview />
 			<RecentEvents />
+			{ ! historyImported && (
+				<SyncHistory
+					sync={ sync }
+					launchHistorySync={ () => launchSync() }
+				/>
+			) }
 			<SyncShowTime
 				sync={ sync }
 				launchRuntimeSync={ () => launchSync( 'total_runtime' ) }

--- a/src/components/SyncHistory.js
+++ b/src/components/SyncHistory.js
@@ -1,0 +1,62 @@
+/**
+ * WordPress dependencies
+ */
+import { Button, Card, CardBody, CardHeader } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Offer to walk back through the Trakt.tv history and import what is missing.
+ *
+ * Traktivity records what you watch from the moment it is set up. Everything
+ * from before that only arrives through this, and a synchronization that was
+ * interrupted, gave up, or ran on a version that stopped early leaves the rest
+ * of the history sitting on Trakt.tv with nothing scheduled to go and get it.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.sync              Current sync state.
+ * @param {Function} props.launchHistorySync Starts the history import.
+ * @return {Element} The card.
+ */
+export default function SyncHistory( { sync, launchHistorySync } ) {
+	const [ launched, setLaunched ] = useState( false );
+
+	/*
+	 * Anything recorded that is not 'done' means an import is under way, either
+	 * one left in progress or the message returned by the request that just
+	 * started one.
+	 */
+	const running = launched || ( !! sync.status && sync.status !== 'done' );
+
+	return (
+		<Card>
+			<CardHeader>
+				<h2>
+					{ __(
+						'Import everything you watched before installing Traktivity.',
+						'traktivity'
+					) }
+				</h2>
+			</CardHeader>
+			<CardBody>
+				<p>
+					{ __(
+						'Traktivity logs what you watch from now on. This goes back through your Trakt.tv history and adds everything that is missing, a batch at a time, so a long history takes a while to come in. Events already imported are left alone, so there is no harm in starting this more than once.',
+						'traktivity'
+					) }
+				</p>
+				<Button
+					variant="secondary"
+					disabled={ running }
+					isBusy={ running }
+					onClick={ () => {
+						setLaunched( true );
+						launchHistorySync();
+					} }
+				>
+					{ __( 'Import past history', 'traktivity' ) }
+				</Button>
+			</CardBody>
+		</Card>
+	);
+}

--- a/src/components/SyncHistory.js
+++ b/src/components/SyncHistory.js
@@ -51,7 +51,17 @@ export default function SyncHistory( { sync, launchHistorySync } ) {
 					isBusy={ running }
 					onClick={ () => {
 						setLaunched( true );
-						launchHistorySync();
+
+						/*
+						 * Let go of the pending flag either way. A request that
+						 * fails leaves the sync status untouched, so holding on
+						 * to it would keep the button stuck with nothing to
+						 * clear it but a page reload. One that works reports a
+						 * status, and that is what keeps the button disabled.
+						 */
+						Promise.resolve( launchHistorySync() ).finally( () =>
+							setLaunched( false )
+						);
 					} }
 				>
 					{ __( 'Import past history', 'traktivity' ) }

--- a/tests/js/dashboard.test.js
+++ b/tests/js/dashboard.test.js
@@ -1,0 +1,93 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import Dashboard from '../../src/components/Dashboard';
+import { resetSettings } from './settings-mock';
+
+jest.mock( '../../src/settings', () => require( './settings-mock' ) );
+
+/*
+ * The dashboard's other cards fetch on mount and have tests of their own. Stub
+ * them so what is asserted here is the dashboard's own behaviour.
+ */
+jest.mock( '../../src/components/RecentEvents', () => () => null );
+jest.mock( '../../src/components/stats/StatsOverview', () => () => null );
+
+/**
+ * Render the finished-setup dashboard with a given sync state.
+ *
+ * @param {Object} sync Sync state to render with.
+ * @return {Function} The launchSync spy the dashboard was given.
+ */
+function renderDashboard( sync ) {
+	resetSettings();
+
+	const launchSync = jest.fn();
+
+	render(
+		<Dashboard
+			sync={ { status: '', pages: 0, runtime: '', ...sync } }
+			launchSync={ launchSync }
+		/>
+	);
+
+	return launchSync;
+}
+
+describe( 'Dashboard', () => {
+	it( 'picks a sync back up when one was left in progress', () => {
+		const launchSync = renderDashboard( {
+			status: 'in_progress',
+			pages: 12,
+		} );
+
+		expect( launchSync ).toHaveBeenCalled();
+	} );
+
+	it( 'does not start a sync on its own once one has finished', () => {
+		const launchSync = renderDashboard( { status: 'done', pages: 0 } );
+
+		expect( launchSync ).not.toHaveBeenCalled();
+	} );
+
+	/*
+	 * An interrupted sync can be sitting on no recorded pages: one that gave up
+	 * before it ever read a page count, or one whose stale status was cleared
+	 * on update so the history could be imported again. Neither should start on
+	 * its own, and both need a way to be started by hand.
+	 */
+	it( 'offers to import past history when no sync has finished', async () => {
+		const user = userEvent.setup();
+		const launchSync = renderDashboard( { status: '', pages: 0 } );
+
+		expect( launchSync ).not.toHaveBeenCalled();
+
+		await user.click(
+			screen.getByRole( 'button', { name: 'Import past history' } )
+		);
+
+		expect( launchSync ).toHaveBeenCalled();
+	} );
+
+	it( 'does not offer the import once the history is in', () => {
+		renderDashboard( { status: 'done', pages: 0 } );
+
+		expect(
+			screen.queryByRole( 'button', { name: 'Import past history' } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the import as running while one is under way', () => {
+		renderDashboard( { status: 'in_progress', pages: 4 } );
+
+		expect(
+			screen.getByRole( 'button', { name: 'Import past history' } )
+		).toBeDisabled();
+	} );
+} );

--- a/tests/js/dashboard.test.js
+++ b/tests/js/dashboard.test.js
@@ -83,6 +83,34 @@ describe( 'Dashboard', () => {
 		).not.toBeInTheDocument();
 	} );
 
+	/*
+	 * launchSync() swallows a failed request without touching the sync status,
+	 * so a component that only ever sets its own pending flag would leave the
+	 * button stuck after one bad request, with no way back but a page reload.
+	 */
+	it( 'lets you try again when starting the import failed', async () => {
+		const user = userEvent.setup();
+
+		resetSettings();
+
+		const launchSync = jest.fn( () => Promise.resolve() );
+
+		render(
+			<Dashboard
+				sync={ { status: '', pages: 0, runtime: '' } }
+				launchSync={ launchSync }
+			/>
+		);
+
+		const button = screen.getByRole( 'button', {
+			name: 'Import past history',
+		} );
+
+		await user.click( button );
+
+		expect( button ).toBeEnabled();
+	} );
+
 	it( 'shows the import as running while one is under way', () => {
 		renderDashboard( { status: 'in_progress', pages: 4 } );
 

--- a/tests/js/setup.test.js
+++ b/tests/js/setup.test.js
@@ -80,7 +80,15 @@ describe( 'Setup', () => {
 	} );
 
 	it( 'resumes an interrupted sync on load', async () => {
-		resetSettings( { step: '5', syncPages: '4' } );
+		/*
+		 * Pages left are only ever recorded alongside an in-progress status, so
+		 * that is what a sync cut short actually looks like on disk.
+		 */
+		resetSettings( {
+			step: '5',
+			syncStatus: 'in_progress',
+			syncPages: '4',
+		} );
 
 		render( <Setup /> );
 

--- a/tests/php/FullSyncTest.php
+++ b/tests/php/FullSyncTest.php
@@ -16,8 +16,8 @@
 class FullSyncTest extends WP_UnitTestCase {
 
 	/**
-	 * Total events in the fake history. Large enough that a page size mix-up
-	 * leaves an obvious hole rather than an off-by-one.
+	 * Total events in the fake history. Enough to need more than one run at
+	 * Traktivity's batch size, so resuming gets exercised too.
 	 *
 	 * @var int
 	 */
@@ -196,6 +196,59 @@ class FullSyncTest extends WP_UnitTestCase {
 			1,
 			$limits,
 			'The sync mixed page sizes: ' . implode( ', ', $limits ) . '.'
+		);
+	}
+
+	/**
+	 * A run that is cut short resumes where it stopped.
+	 *
+	 * The sync runs on cron and can be killed at any point. It records how many
+	 * pages are left after each one, so the next run picks those up rather than
+	 * starting the whole history over.
+	 */
+	public function test_progress_survives_a_run_that_does_not_finish() {
+		do_action( 'traktivity_full_sync' );
+
+		$options = get_option( 'traktivity' );
+
+		$this->assertSame(
+			'in_progress',
+			$options['full_sync']['status'],
+			'A history this size should take more than one run.'
+		);
+		$this->assertGreaterThan( 0, $options['full_sync']['pages'], 'Pages left should be recorded.' );
+
+		$after_first_run = $options['full_sync']['pages'];
+		$first_run_pages = wp_list_pluck( $this->requests, 'page' );
+
+		do_action( 'traktivity_full_sync' );
+
+		$options = get_option( 'traktivity' );
+
+		$this->assertLessThan(
+			$after_first_run,
+			$options['full_sync']['pages'],
+			'The second run should have fewer pages left than the first.'
+		);
+
+		$second_run_pages = array_slice( wp_list_pluck( $this->requests, 'page' ), count( $first_run_pages ) );
+
+		$this->assertSame(
+			array(),
+			array_values( array_intersect( $first_run_pages, $second_run_pages ) ),
+			'The second run re-fetched pages the first run had already done.'
+		);
+	}
+
+	/**
+	 * An unfinished run queues the next one, so the sync finishes on its own.
+	 */
+	public function test_an_unfinished_run_schedules_the_next_one() {
+		do_action( 'traktivity_full_sync' );
+
+		$this->assertNotFalse(
+			wp_next_scheduled( 'traktivity_full_sync' ),
+			'A sync with pages left should have queued another run.'
 		);
 	}
 

--- a/tests/php/FullSyncTest.php
+++ b/tests/php/FullSyncTest.php
@@ -78,6 +78,14 @@ class FullSyncTest extends WP_UnitTestCase {
 	private $runtime_finishes_on_page = null;
 
 	/**
+	 * Whether the fake Trakt.tv answers 200 but leaves the pagination header
+	 * off, standing in for a response we cannot make sense of.
+	 *
+	 * @var bool
+	 */
+	private $omit_page_count_header = false;
+
+	/**
 	 * Point the plugin at a username and key, and swap Trakt.tv for the fake.
 	 */
 	public function set_up() {
@@ -97,6 +105,7 @@ class FullSyncTest extends WP_UnitTestCase {
 		$this->failing_page             = null;
 		$this->fail_page_count          = false;
 		$this->runtime_finishes_on_page = null;
+		$this->omit_page_count_header   = false;
 
 		add_filter( 'pre_http_request', array( $this, 'fake_trakt' ), 10, 3 );
 	}
@@ -184,13 +193,17 @@ class FullSyncTest extends WP_UnitTestCase {
 		 * them in title case. Build the same structure a real request would,
 		 * so the test cannot pass on a casing the network would never produce.
 		 */
-		$headers = new WpOrg\Requests\Utility\CaseInsensitiveDictionary(
-			array(
-				'x-pagination-item-count' => (string) $this->history_size,
-				'x-pagination-limit'      => (string) $limit,
-				'x-pagination-page-count' => (string) (int) ceil( $this->history_size / $limit ),
-			)
+		$sent = array(
+			'x-pagination-item-count' => (string) $this->history_size,
+			'x-pagination-limit'      => (string) $limit,
+			'x-pagination-page-count' => (string) (int) ceil( $this->history_size / $limit ),
 		);
+
+		if ( $this->omit_page_count_header ) {
+			unset( $sent['x-pagination-page-count'] );
+		}
+
+		$headers = new WpOrg\Requests\Utility\CaseInsensitiveDictionary( $sent );
 
 		return array(
 			'headers'  => $headers,
@@ -426,8 +439,124 @@ class FullSyncTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A failed page-count request leaves no sync state behind, so the next run
-	 * asks Trakt.tv again instead of sitting in progress with nothing to fetch.
+	 * A response with no page count is a failure, not an empty history.
+	 *
+	 * Trakt.tv sends the count on every paginated response. Reading a missing
+	 * one as zero would end the sync as complete with the whole history still
+	 * sitting on Trakt.tv, which is the failure this release exists to fix.
+	 */
+	public function test_a_response_without_a_page_count_is_not_read_as_an_empty_history() {
+		$this->omit_page_count_header = true;
+
+		do_action( 'traktivity_full_sync' );
+
+		$options = get_option( 'traktivity' );
+
+		$this->assertNotSame(
+			'done',
+			$options['full_sync']['status'] ?? '',
+			'A response we could not read was treated as a finished sync.'
+		);
+	}
+
+	/**
+	 * A request that keeps failing eventually stops asking.
+	 *
+	 * Every non-200 arrives here the same way, so a wrong API key or a
+	 * username that no longer exists looks exactly like a timeout. Queueing a
+	 * fresh run each time would leave the site asking Trakt.tv once a minute
+	 * for as long as the key stays wrong.
+	 */
+	public function test_a_request_that_keeps_failing_stops_being_retried() {
+		$this->fail_page_count = true;
+
+		for ( $attempt = 1; $attempt <= 20; $attempt++ ) {
+			$scheduled = wp_next_scheduled( 'traktivity_full_sync' );
+
+			if ( false !== $scheduled ) {
+				wp_unschedule_event( $scheduled, 'traktivity_full_sync' );
+			}
+
+			do_action( 'traktivity_full_sync' );
+
+			if ( false === wp_next_scheduled( 'traktivity_full_sync' ) ) {
+				break;
+			}
+		}
+
+		$this->assertFalse(
+			wp_next_scheduled( 'traktivity_full_sync' ),
+			'The sync kept queueing itself even though every request failed.'
+		);
+		$this->assertLessThan( 20, $attempt, 'It took too many attempts to give up.' );
+	}
+
+	/**
+	 * A page that comes good clears the failure count, so a later outage gets
+	 * a full set of attempts of its own rather than inheriting old ones.
+	 */
+	public function test_a_successful_page_clears_earlier_failures() {
+		$pages_total = (int) ceil( self::HISTORY_SIZE / 100 );
+
+		$this->failing_page = $pages_total;
+
+		do_action( 'traktivity_full_sync' );
+
+		$options = get_option( 'traktivity' );
+		$this->assertSame( 1, $options['full_sync']['failures'] ?? 0 );
+
+		$this->failing_page = null;
+
+		do_action( 'traktivity_full_sync' );
+
+		$options = get_option( 'traktivity' );
+		$this->assertSame( 0, $options['full_sync']['failures'] ?? -1 );
+	}
+
+	/**
+	 * Asking for a synchronization from the dashboard starts the attempts over.
+	 *
+	 * A sync that gave up because Trakt.tv kept refusing it would otherwise
+	 * carry that tally into the run the reader just asked for, and stop again
+	 * on the first hiccup rather than trying properly.
+	 */
+	public function test_starting_a_sync_by_hand_clears_the_failure_count() {
+		update_option(
+			'traktivity',
+			array(
+				'username'  => 'jeherve',
+				'api_key'   => 'test-key',
+				'full_sync' => array(
+					'status'   => 'in_progress',
+					'pages'    => 4,
+					'failures' => 5,
+				),
+			)
+		);
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		do_action( 'rest_api_init', $wp_rest_server );
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$response = rest_get_server()->dispatch( new WP_REST_Request( 'POST', '/traktivity/v1/sync' ) );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$options = get_option( 'traktivity' );
+
+		$this->assertArrayNotHasKey( 'failures', $options['full_sync'] );
+		$this->assertSame( 4, $options['full_sync']['pages'], 'Progress so far should be left alone.' );
+	}
+
+	/**
+	 * A failed page-count request records no page count and no progress, so
+	 * the next run asks Trakt.tv again instead of sitting in progress with
+	 * nothing to fetch.
+	 *
+	 * The count of failed attempts is written, since that is what stops the
+	 * retries eventually, but it says nothing about a sync being under way.
 	 */
 	public function test_a_failed_page_count_request_does_not_start_a_sync() {
 		remove_filter( 'pre_http_request', array( $this, 'fake_trakt' ), 10 );
@@ -439,6 +568,7 @@ class FullSyncTest extends WP_UnitTestCase {
 
 		$options = get_option( 'traktivity' );
 
-		$this->assertArrayNotHasKey( 'full_sync', $options );
+		$this->assertArrayNotHasKey( 'pages', $options['full_sync'] );
+		$this->assertArrayNotHasKey( 'status', $options['full_sync'] );
 	}
 }

--- a/tests/php/FullSyncTest.php
+++ b/tests/php/FullSyncTest.php
@@ -31,6 +31,13 @@ class FullSyncTest extends WP_UnitTestCase {
 	private const TRAKT_DEFAULT_LIMIT = 100;
 
 	/**
+	 * Mirrors the plugin's own ceiling on requests failed in a row.
+	 *
+	 * @var int
+	 */
+	private const MAX_ATTEMPTS = 5;
+
+	/**
 	 * Every history request the sync made, as `array( page, limit )` pairs.
 	 *
 	 * @var array<int, array{page: int|null, limit: int}>
@@ -548,6 +555,94 @@ class FullSyncTest extends WP_UnitTestCase {
 
 		$this->assertArrayNotHasKey( 'failures', $options['full_sync'] );
 		$this->assertSame( 4, $options['full_sync']['pages'], 'Progress so far should be left alone.' );
+	}
+
+	/**
+	 * Failures are counted per run of bad luck, not for the life of the sync.
+	 *
+	 * The count that matters is how many requests failed in a row. A page count
+	 * that comes good ends the previous streak, so a page failing right after
+	 * it starts a new one rather than inheriting attempts already spent.
+	 */
+	public function test_a_page_count_that_succeeds_ends_the_previous_streak() {
+		update_option(
+			'traktivity',
+			array(
+				'username'  => 'jeherve',
+				'api_key'   => 'test-key',
+				'full_sync' => array( 'failures' => self::MAX_ATTEMPTS - 1 ),
+			)
+		);
+
+		// The count works, then the very first page does not.
+		$this->failing_page = (int) ceil( self::HISTORY_SIZE / 100 );
+
+		do_action( 'traktivity_full_sync' );
+
+		$options = get_option( 'traktivity' );
+
+		$this->assertSame(
+			1,
+			$options['full_sync']['failures'],
+			'The failed page should have started a new streak, not continued the old one.'
+		);
+		$this->assertNotFalse(
+			wp_next_scheduled( 'traktivity_full_sync' ),
+			'With attempts left, the sync should have queued another run.'
+		);
+	}
+
+	/**
+	 * A run killed part way through gets picked back up on its own.
+	 *
+	 * WordPress clears a single event before running it, so a run that dies
+	 * mid-batch leaves a sync in progress with nothing queued to carry it on.
+	 * The hourly check for new events notices and puts it back on the schedule,
+	 * rather than leaving it until someone opens the dashboard.
+	 */
+	public function test_the_hourly_check_picks_up_a_sync_that_stalled() {
+		update_option(
+			'traktivity',
+			array(
+				'username'  => 'jeherve',
+				'api_key'   => 'test-key',
+				'full_sync' => array(
+					'status'  => 'in_progress',
+					'pages'   => 6,
+					'updated' => time() - HOUR_IN_SECONDS,
+				),
+			)
+		);
+
+		do_action( 'traktivity_publish' );
+
+		$this->assertNotFalse(
+			wp_next_scheduled( 'traktivity_full_sync' ),
+			'A sync left in progress with nothing queued should have been picked back up.'
+		);
+	}
+
+	/**
+	 * A sync that is simply still working is left alone, so the hourly check
+	 * does not put a second run alongside one already going.
+	 */
+	public function test_the_hourly_check_leaves_a_working_sync_alone() {
+		update_option(
+			'traktivity',
+			array(
+				'username'  => 'jeherve',
+				'api_key'   => 'test-key',
+				'full_sync' => array(
+					'status'  => 'in_progress',
+					'pages'   => 6,
+					'updated' => time(),
+				),
+			)
+		);
+
+		do_action( 'traktivity_publish' );
+
+		$this->assertFalse( wp_next_scheduled( 'traktivity_full_sync' ) );
 	}
 
 	/**

--- a/tests/php/FullSyncTest.php
+++ b/tests/php/FullSyncTest.php
@@ -61,6 +61,23 @@ class FullSyncTest extends WP_UnitTestCase {
 	private $failing_page = null;
 
 	/**
+	 * Whether the fake Trakt.tv refuses the request that asks how many pages
+	 * of history there are.
+	 *
+	 * @var bool
+	 */
+	private $fail_page_count = false;
+
+	/**
+	 * Page number after which the runtime recalculation records itself as
+	 * finished, standing in for that job's cron event landing part way through
+	 * a history sync. Null leaves the two jobs to run apart.
+	 *
+	 * @var int|null
+	 */
+	private $runtime_finishes_on_page = null;
+
+	/**
 	 * Point the plugin at a username and key, and swap Trakt.tv for the fake.
 	 */
 	public function set_up() {
@@ -74,10 +91,12 @@ class FullSyncTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->requests     = array();
-		$this->served       = array();
-		$this->history_size = self::HISTORY_SIZE;
-		$this->failing_page = null;
+		$this->requests                 = array();
+		$this->served                   = array();
+		$this->history_size             = self::HISTORY_SIZE;
+		$this->failing_page             = null;
+		$this->fail_page_count          = false;
+		$this->runtime_finishes_on_page = null;
 
 		add_filter( 'pre_http_request', array( $this, 'fake_trakt' ), 10, 3 );
 	}
@@ -116,8 +135,24 @@ class FullSyncTest extends WP_UnitTestCase {
 			'limit' => $limit,
 		);
 
+		/*
+		 * Stand in for the other cron job finishing while this sync is part way
+		 * through, writing its own key into the shared option.
+		 */
+		if ( null !== $this->runtime_finishes_on_page && $page === $this->runtime_finishes_on_page ) {
+			$options                         = get_option( 'traktivity' );
+			$options['full_sync']['runtime'] = array(
+				'status' => 'done',
+				'items'  => 0,
+			);
+			update_option( 'traktivity', $options );
+		}
+
 		// Stand in for a page Trakt.tv could not serve on this attempt.
-		if ( null !== $this->failing_page && $page === $this->failing_page ) {
+		if (
+			( null === $page && $this->fail_page_count )
+			|| ( null !== $this->failing_page && $page === $this->failing_page )
+		) {
 			return array(
 				'headers'  => new WpOrg\Requests\Utility\CaseInsensitiveDictionary( array() ),
 				'body'     => '',
@@ -343,6 +378,51 @@ class FullSyncTest extends WP_UnitTestCase {
 		$missing = array_diff( range( 1, $this->history_size ), $this->served );
 
 		$this->assertSame( array(), array_values( $missing ), 'Events from the failed page never arrived.' );
+	}
+
+	/**
+	 * A page count Trakt.tv could not give us gets asked for again.
+	 *
+	 * The sync runs on a one-shot cron event, so returning without queueing
+	 * another one ends it there. Nothing is saved in this case either, so the
+	 * dashboard sees no sync in progress and its own resume path never fires:
+	 * a synchronization the reader was told had started would just stop.
+	 */
+	public function test_a_failed_page_count_queues_another_run() {
+		$this->fail_page_count = true;
+
+		do_action( 'traktivity_full_sync' );
+
+		$this->assertNotFalse(
+			wp_next_scheduled( 'traktivity_full_sync' ),
+			'A sync that could not read the page count should have queued another run.'
+		);
+	}
+
+	/**
+	 * The runtime recalculation's progress survives a history sync.
+	 *
+	 * Both jobs keep their state in the same 'full_sync' option and each has
+	 * its own cron event, so they can overlap. Writing back a copy of the
+	 * option taken at the start of a run would put back whatever the other job
+	 * had recorded since, undoing finished work.
+	 */
+	public function test_a_history_sync_leaves_the_runtime_job_state_alone() {
+		$pages_total = (int) ceil( self::HISTORY_SIZE / 100 );
+
+		// The runtime job finishes while the history sync is mid-run.
+		$this->runtime_finishes_on_page = $pages_total - 2;
+
+		$this->sync_to_completion();
+
+		$options = get_option( 'traktivity' );
+
+		$this->assertSame(
+			'done',
+			$options['full_sync']['runtime']['status'] ?? '',
+			'The history sync wrote over the runtime job\'s state.'
+		);
+		$this->assertSame( 'done', $options['full_sync']['status'] );
 	}
 
 	/**

--- a/tests/php/FullSyncTest.php
+++ b/tests/php/FullSyncTest.php
@@ -45,6 +45,22 @@ class FullSyncTest extends WP_UnitTestCase {
 	private $served = array();
 
 	/**
+	 * Events the fake Trakt.tv holds. Defaults to a history big enough to need
+	 * more than one run; tests set it to zero to stand in for a fresh account.
+	 *
+	 * @var int
+	 */
+	private $history_size = self::HISTORY_SIZE;
+
+	/**
+	 * Page number the fake Trakt.tv refuses to serve, standing in for a
+	 * timeout or a rate limit part way through a run. Null serves every page.
+	 *
+	 * @var int|null
+	 */
+	private $failing_page = null;
+
+	/**
 	 * Point the plugin at a username and key, and swap Trakt.tv for the fake.
 	 */
 	public function set_up() {
@@ -58,8 +74,10 @@ class FullSyncTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->requests = array();
-		$this->served   = array();
+		$this->requests     = array();
+		$this->served       = array();
+		$this->history_size = self::HISTORY_SIZE;
+		$this->failing_page = null;
 
 		add_filter( 'pre_http_request', array( $this, 'fake_trakt' ), 10, 3 );
 	}
@@ -98,13 +116,25 @@ class FullSyncTest extends WP_UnitTestCase {
 			'limit' => $limit,
 		);
 
+		// Stand in for a page Trakt.tv could not serve on this attempt.
+		if ( null !== $this->failing_page && $page === $this->failing_page ) {
+			return array(
+				'headers'  => new WpOrg\Requests\Utility\CaseInsensitiveDictionary( array() ),
+				'body'     => '',
+				'response' => array(
+					'code'    => 503,
+					'message' => 'Service Unavailable',
+				),
+			);
+		}
+
 		/*
 		 * Trakt.tv returns the history newest first, so page 1 holds the most
 		 * recent events. Hand back bare objects: the sync skips events with no
 		 * type, which keeps this about pagination rather than post creation.
 		 */
 		$offset = ( ( null === $page ? 1 : $page ) - 1 ) * $limit;
-		$end    = min( $offset + $limit, self::HISTORY_SIZE );
+		$end    = min( $offset + $limit, $this->history_size );
 		$body   = array();
 
 		for ( $i = $offset; $i < $end; $i++ ) {
@@ -121,9 +151,9 @@ class FullSyncTest extends WP_UnitTestCase {
 		 */
 		$headers = new WpOrg\Requests\Utility\CaseInsensitiveDictionary(
 			array(
-				'x-pagination-item-count' => (string) self::HISTORY_SIZE,
+				'x-pagination-item-count' => (string) $this->history_size,
 				'x-pagination-limit'      => (string) $limit,
-				'x-pagination-page-count' => (string) (int) ceil( self::HISTORY_SIZE / $limit ),
+				'x-pagination-page-count' => (string) (int) ceil( $this->history_size / $limit ),
 			)
 		);
 
@@ -171,12 +201,12 @@ class FullSyncTest extends WP_UnitTestCase {
 	public function test_sync_walks_the_entire_history() {
 		$this->sync_to_completion();
 
-		$missing = array_diff( range( 1, self::HISTORY_SIZE ), $this->served );
+		$missing = array_diff( range( 1, $this->history_size ), $this->served );
 
 		$this->assertSame(
 			array(),
 			array_values( $missing ),
-			sprintf( 'The sync never fetched %d of the %d events in the history.', count( $missing ), self::HISTORY_SIZE )
+			sprintf( 'The sync never fetched %d of the %d events in the history.', count( $missing ), $this->history_size )
 		);
 	}
 
@@ -250,6 +280,69 @@ class FullSyncTest extends WP_UnitTestCase {
 			wp_next_scheduled( 'traktivity_full_sync' ),
 			'A sync with pages left should have queued another run.'
 		);
+	}
+
+	/**
+	 * An account with nothing watched yet finishes, rather than asking
+	 * Trakt.tv for a page count on every run forever.
+	 *
+	 * A failed request and an empty history both used to arrive as a page count
+	 * of zero, and both were read as failure, so a fresh account could never
+	 * reach 'done'.
+	 */
+	public function test_an_empty_history_completes_the_sync() {
+		$this->history_size = 0;
+
+		do_action( 'traktivity_full_sync' );
+
+		$options = get_option( 'traktivity' );
+
+		$this->assertSame( 'done', $options['full_sync']['status'] );
+		$this->assertSame( 0, $options['full_sync']['pages'] );
+	}
+
+	/**
+	 * A page Trakt.tv fails to serve is tried again, not stepped over.
+	 *
+	 * The sync records its progress as it goes, so it has to be sure a page
+	 * really arrived before counting it done. Otherwise one timeout drops a
+	 * whole page of events on the floor and the sync still finishes 'done',
+	 * which is the silent partial import this release is about.
+	 */
+	public function test_a_page_that_fails_to_load_is_not_skipped() {
+		$pages_total = (int) ceil( self::HISTORY_SIZE / 100 );
+
+		// Fail a page in the middle of the first run.
+		$this->failing_page = $pages_total - 3;
+
+		do_action( 'traktivity_full_sync' );
+
+		$options = get_option( 'traktivity' );
+
+		$this->assertNotSame(
+			'done',
+			$options['full_sync']['status'] ?? '',
+			'A sync that could not read a page should not report itself finished.'
+		);
+		$this->assertSame(
+			$this->failing_page,
+			$options['full_sync']['pages'],
+			'The next run should start again at the page that failed.'
+		);
+
+		// Let it through, and the run that follows should pick up that page.
+		$this->failing_page = null;
+		$before             = count( $this->requests );
+
+		$this->sync_to_completion();
+
+		$retried = array_slice( wp_list_pluck( $this->requests, 'page' ), $before );
+
+		$this->assertContains( $pages_total - 3, $retried, 'The failed page was never requested again.' );
+
+		$missing = array_diff( range( 1, $this->history_size ), $this->served );
+
+		$this->assertSame( array(), array_values( $missing ), 'Events from the failed page never arrived.' );
 	}
 
 	/**

--- a/tests/php/FullSyncTest.php
+++ b/tests/php/FullSyncTest.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * Tests for the full history sync loop.
+ *
+ * @package Traktivity
+ */
+
+/**
+ * Traktivity_Calls::full_sync().
+ *
+ * These tests stand a fake Trakt.tv in front of the sync and check which slice
+ * of the history it actually walks. The fake paginates the way Trakt.tv does:
+ * `limit` defaults to 100 when the caller omits it, and the page count in the
+ * response header is derived from whatever limit ended up applying.
+ */
+class FullSyncTest extends WP_UnitTestCase {
+
+	/**
+	 * Total events in the fake history. Large enough that a page size mix-up
+	 * leaves an obvious hole rather than an off-by-one.
+	 *
+	 * @var int
+	 */
+	private const HISTORY_SIZE = 1500;
+
+	/**
+	 * Trakt.tv's own default page size, applied when a request omits `limit`.
+	 *
+	 * @var int
+	 */
+	private const TRAKT_DEFAULT_LIMIT = 100;
+
+	/**
+	 * Every history request the sync made, as `array( page, limit )` pairs.
+	 *
+	 * @var array<int, array{page: int|null, limit: int}>
+	 */
+	private $requests = array();
+
+	/**
+	 * IDs of every event the fake Trakt.tv handed back to the sync.
+	 *
+	 * @var int[]
+	 */
+	private $served = array();
+
+	/**
+	 * Point the plugin at a username and key, and swap Trakt.tv for the fake.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		update_option(
+			'traktivity',
+			array(
+				'username' => 'jeherve',
+				'api_key'  => 'test-key',
+			)
+		);
+
+		$this->requests = array();
+		$this->served   = array();
+
+		add_filter( 'pre_http_request', array( $this, 'fake_trakt' ), 10, 3 );
+	}
+
+	/**
+	 * Drop the fake so it cannot leak into other tests.
+	 */
+	public function tear_down() {
+		remove_filter( 'pre_http_request', array( $this, 'fake_trakt' ), 10 );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Stand in for Trakt.tv's /users/:id/history endpoint.
+	 *
+	 * @param false|array|WP_Error $response Preempted response. False to let the request through.
+	 * @param array                $args     Request arguments.
+	 * @param string               $url      Request URL.
+	 *
+	 * @return false|array Fake response, or false for anything that is not the history endpoint.
+	 */
+	public function fake_trakt( $response, $args, $url ) {
+		if ( false === strpos( $url, 'api.trakt.tv' ) ) {
+			return $response;
+		}
+
+		$query = array();
+		parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $query );
+
+		$limit = isset( $query['limit'] ) ? (int) $query['limit'] : self::TRAKT_DEFAULT_LIMIT;
+		$page  = isset( $query['page'] ) ? (int) $query['page'] : null;
+
+		$this->requests[] = array(
+			'page'  => $page,
+			'limit' => $limit,
+		);
+
+		/*
+		 * Trakt.tv returns the history newest first, so page 1 holds the most
+		 * recent events. Hand back bare objects: the sync skips events with no
+		 * type, which keeps this about pagination rather than post creation.
+		 */
+		$offset = ( ( null === $page ? 1 : $page ) - 1 ) * $limit;
+		$end    = min( $offset + $limit, self::HISTORY_SIZE );
+		$body   = array();
+
+		for ( $i = $offset; $i < $end; $i++ ) {
+			$id             = $i + 1;
+			$this->served[] = $id;
+			$body[]         = array( 'id' => $id );
+		}
+
+		/*
+		 * WP_Http hands headers back in a case-insensitive dictionary, and
+		 * Trakt.tv sends these lowercase over HTTP/2 while the plugin reads
+		 * them in title case. Build the same structure a real request would,
+		 * so the test cannot pass on a casing the network would never produce.
+		 */
+		$headers = new WpOrg\Requests\Utility\CaseInsensitiveDictionary(
+			array(
+				'x-pagination-item-count' => (string) self::HISTORY_SIZE,
+				'x-pagination-limit'      => (string) $limit,
+				'x-pagination-page-count' => (string) (int) ceil( self::HISTORY_SIZE / $limit ),
+			)
+		);
+
+		return array(
+			'headers'  => $headers,
+			'body'     => wp_json_encode( $body ),
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+		);
+	}
+
+	/**
+	 * Run the sync until it reports itself done, or until it stops making
+	 * progress. Each run stands in for one firing of the cron event.
+	 *
+	 * @param int $max_runs Give up after this many runs, so a stalled sync fails the test rather than hanging it.
+	 *
+	 * @return int Number of runs it took.
+	 */
+	private function sync_to_completion( $max_runs = 20 ) {
+		for ( $run = 1; $run <= $max_runs; $run++ ) {
+			do_action( 'traktivity_full_sync' );
+
+			$options = get_option( 'traktivity' );
+
+			if ( isset( $options['full_sync']['status'] ) && 'done' === $options['full_sync']['status'] ) {
+				return $run;
+			}
+		}
+
+		$this->fail( sprintf( 'Sync did not finish within %d runs.', $max_runs ) );
+	}
+
+	/**
+	 * The whole history ends up imported.
+	 *
+	 * Traktivity asks Trakt.tv how many pages of history there are, then walks
+	 * that many pages. Both calls have to agree on a page size: ask for the
+	 * count at Trakt.tv's default of 100 and then walk the pages at 10, and the
+	 * loop only ever covers a tenth of the history before declaring itself
+	 * done.
+	 */
+	public function test_sync_walks_the_entire_history() {
+		$this->sync_to_completion();
+
+		$missing = array_diff( range( 1, self::HISTORY_SIZE ), $this->served );
+
+		$this->assertSame(
+			array(),
+			array_values( $missing ),
+			sprintf( 'The sync never fetched %d of the %d events in the history.', count( $missing ), self::HISTORY_SIZE )
+		);
+	}
+
+	/**
+	 * The page-count request and the pages it walks use the same page size.
+	 *
+	 * This is the root cause of the partial import, stated directly: the count
+	 * describes pages of a given size, so fetching pages of a different size
+	 * makes the count mean nothing.
+	 */
+	public function test_page_count_request_and_page_requests_agree_on_limit() {
+		$this->sync_to_completion();
+
+		$limits = array_unique( wp_list_pluck( $this->requests, 'limit' ) );
+
+		$this->assertCount(
+			1,
+			$limits,
+			'The sync mixed page sizes: ' . implode( ', ', $limits ) . '.'
+		);
+	}
+
+	/**
+	 * A failed page-count request leaves no sync state behind, so the next run
+	 * asks Trakt.tv again instead of sitting in progress with nothing to fetch.
+	 */
+	public function test_a_failed_page_count_request_does_not_start_a_sync() {
+		remove_filter( 'pre_http_request', array( $this, 'fake_trakt' ), 10 );
+		add_filter( 'pre_http_request', '__return_empty_array' );
+
+		do_action( 'traktivity_full_sync' );
+
+		remove_filter( 'pre_http_request', '__return_empty_array' );
+
+		$options = get_option( 'traktivity' );
+
+		$this->assertArrayNotHasKey( 'full_sync', $options );
+	}
+}

--- a/tests/php/PluginTest.php
+++ b/tests/php/PluginTest.php
@@ -35,6 +35,84 @@ class PluginTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A site that last ran a version whose full sync only ever imported part
+	 * of the history gets that sync's status cleared, so the dashboard offers
+	 * to run it again rather than reporting a partial import as complete.
+	 */
+	public function test_upgrade_clears_a_full_sync_status_from_before_3_0_1() {
+		update_option(
+			'traktivity',
+			array(
+				'username'  => 'jeherve',
+				'full_sync' => array(
+					'status' => 'done',
+					'pages'  => 0,
+				),
+			)
+		);
+
+		Traktivity::get_instance()->maybe_upgrade();
+
+		$options = get_option( 'traktivity' );
+
+		$this->assertArrayNotHasKey( 'status', $options['full_sync'] );
+		$this->assertArrayNotHasKey( 'pages', $options['full_sync'] );
+		$this->assertSame( 'jeherve', $options['username'], 'The rest of the settings should be left alone.' );
+		$this->assertSame( TRAKTIVITY__VERSION, $options['version'] );
+	}
+
+	/**
+	 * The same option tracks the separate recalculation of each show's total
+	 * runtime. That one was never broken, so clearing the history sync has to
+	 * leave it be, or finished work gets reported as never run.
+	 */
+	public function test_upgrade_keeps_the_total_runtime_status() {
+		update_option(
+			'traktivity',
+			array(
+				'full_sync' => array(
+					'status'  => 'done',
+					'pages'   => 0,
+					'runtime' => array(
+						'status' => 'done',
+						'items'  => 0,
+					),
+				),
+			)
+		);
+
+		Traktivity::get_instance()->maybe_upgrade();
+
+		$options = get_option( 'traktivity' );
+
+		$this->assertSame( 'done', $options['full_sync']['runtime']['status'] );
+		$this->assertArrayNotHasKey( 'status', $options['full_sync'], 'The history sync status should still be cleared.' );
+	}
+
+	/**
+	 * Having run the routine once, a plain page load leaves a sync that is
+	 * genuinely finished alone.
+	 */
+	public function test_upgrade_leaves_a_current_install_alone() {
+		update_option(
+			'traktivity',
+			array(
+				'version'   => TRAKTIVITY__VERSION,
+				'full_sync' => array(
+					'status' => 'done',
+					'pages'  => 0,
+				),
+			)
+		);
+
+		Traktivity::get_instance()->maybe_upgrade();
+
+		$options = get_option( 'traktivity' );
+
+		$this->assertSame( 'done', $options['full_sync']['status'] );
+	}
+
+	/**
 	 * Events are exposed to the REST API, which the dashboard's recent list
 	 * reads through /wp/v2/traktivity_event.
 	 */

--- a/traktivity.php
+++ b/traktivity.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://wordpress.org/plugins/traktivity
  * Description: Log your activity on Trakt.tv
  * Author: Jeremy Herve
- * Version: 3.0.0
+ * Version: 3.0.1
  * Author URI: https://jeremy.hu
  * Requires at least: 7.0
  * Requires PHP: 7.4
@@ -17,7 +17,7 @@
 
 defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
 
-define( 'TRAKTIVITY__VERSION', '3.0.0' );
+define( 'TRAKTIVITY__VERSION', '3.0.1' );
 define( 'TRAKTIVITY__API_URL', 'https://api.trakt.tv' );
 define( 'TRAKTIVITY__API_VERSION', '2' );
 define( 'TRAKTIVITY__TMDB_API_URL', 'https://api.themoviedb.org' );
@@ -54,6 +54,8 @@ class Traktivity {
 		add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
 		// Load plugin.
 		add_action( 'plugins_loaded', array( $this, 'load_plugin' ) );
+		// Run one-time routines after an update.
+		add_action( 'plugins_loaded', array( $this, 'maybe_upgrade' ) );
 		// Flush rewrite rewrite_rules.
 		add_action( 'add_option_traktivity_event', array( $this, 'flush_rules_on_enable' ) );
 		add_action( 'update_option_traktivity_event', array( $this, 'flush_rules_on_enable' ) );
@@ -66,6 +68,51 @@ class Traktivity {
 	 */
 	public function load_textdomain() {
 		load_plugin_textdomain( 'traktivity', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
+	}
+
+	/**
+	 * Run one-time routines when the plugin is updated.
+	 *
+	 * The version the site last ran is recorded alongside the other settings,
+	 * so this can tell an update from a plain page load.
+	 *
+	 * @since 3.0.1
+	 */
+	public function maybe_upgrade() {
+		$options = get_option( 'traktivity' );
+
+		// Nothing configured yet, so there is nothing to bring forward.
+		if ( ! is_array( $options ) ) {
+			return;
+		}
+
+		$previous = isset( $options['version'] ) ? (string) $options['version'] : '0';
+
+		if ( version_compare( $previous, TRAKTIVITY__VERSION, '>=' ) ) {
+			return;
+		}
+
+		/*
+		 * Up to 3.0.1, a full synchronization asked Trakt.tv how many pages of
+		 * history there were at one page size and then walked those pages at
+		 * another, so it covered a tenth of the history and marked itself done.
+		 * Every site that ran it is sitting on a partial import that the
+		 * dashboard refuses to run again, so clear that status and let them.
+		 *
+		 * Events are keyed on their Trakt.tv ID and skipped if already present,
+		 * so the run that follows only fills in what is missing.
+		 *
+		 * Only the history keys go. The same option also tracks the separate
+		 * recalculation of each show's total runtime, under 'runtime', and that
+		 * one worked: clearing it too would report finished work as never run.
+		 */
+		if ( version_compare( $previous, '3.0.1', '<' ) && isset( $options['full_sync'] ) ) {
+			unset( $options['full_sync']['status'], $options['full_sync']['pages'] );
+		}
+
+		$options['version'] = TRAKTIVITY__VERSION;
+
+		update_option( 'traktivity', $options );
 	}
 
 	/**

--- a/traktivity.php
+++ b/traktivity.php
@@ -93,7 +93,7 @@ class Traktivity {
 		}
 
 		/*
-		 * Up to 3.0.1, a full synchronization asked Trakt.tv how many pages of
+		 * Before 3.0.1, a full synchronization asked Trakt.tv how many pages of
 		 * history there were at one page size and then walked those pages at
 		 * another, so it covered a tenth of the history and marked itself done.
 		 * Every site that ran it is sitting on a partial import that the


### PR DESCRIPTION
## What it does

A full synchronization imported the newest tenth of my Trakt.tv history and then reported itself complete. On my own site that was 921 of 9,113 events, with nothing at all before August 2022.

`full_sync()` asks Trakt.tv how many pages of history there are, then walks that many pages. Both calls have to agree on a page size, and they didn't. The count request sent no `limit`; the loop that followed asked for pages of 10.

| Request | `X-Pagination-Limit` | `X-Pagination-Page-Count` |
|---|---|---|
| no `limit` (the count request) | 100 | 92 |
| `limit=10` (the loop) | 10 | 912 |

So the loop walked 92 pages of 10 items, ran out of pages after 920 events, and called it done.

Three commits:

1. Send the page size explicitly on both calls, from one constant.
2. Save the pages left after each page, and stop after ten pages to queue the next run.
3. Clear the stale sync status once on upgrade, so sites holding a partial import can run the synchronization again.

## Rationale

The count request sent no `limit` because it didn't need one. Trakt.tv documented a default of 10 back when I wrote this in 87b459c, in February 2017, and the loop was built around that. [The docs still say 10 today](https://docs.trakt.tv/docs/pagination), last updated in May 2025. The API no longer agrees with them: it returns 100 by default now, on every paginated endpoint I tried. The default the code leaned on changed underneath it while the documented contract stayed put, so nothing ever errored, and I only noticed because the site stopped at 2022.

Fixing the page size on its own would have left the sync correct but unable to finish. It turns a 92-page walk into one covering the whole history, and the old loop saved nothing until the very end, so any run that got cut short threw its work away and started from the top again. Hence the batching.

The upgrade routine is there because the first two commits are inert without it. Every install that ever ran a synchronization is holding `full_sync => done`, and the REST endpoint answers "Synchronization is complete." to any attempt to start another one.

A few things this deliberately doesn't do:

- Nothing starts on its own at upgrade. The status is cleared and the dashboard offers the synchronization again; taking it is your choice.
- Only the history keys are cleared. That same option also tracks the show runtime recalculation under `runtime`, which was never broken.
- The loop still walks pages by number, oldest to newest, so watches added while a sync is running shift the numbering and a page can be missed. The hourly `traktivity_publish` keeps picking up the newest page, so the front of the history fills in anyway. A cursor-based walk would be sturdier, and a bigger change than I wanted to make while fixing a page count :)

## Usage example

The count request, before and after:

```
# Before: no limit, so Trakt.tv answers for pages of 100
$ curl -sD - 'https://api.trakt.tv/users/jeherve/history?extended=full' -o /dev/null
x-pagination-limit: 100
x-pagination-page-count: 92    # then walked as 92 pages of 10 = 920 events

# After: same page size on both calls
$ curl -sD - 'https://api.trakt.tv/users/jeherve/history?extended=full&limit=100' -o /dev/null
x-pagination-limit: 100
x-pagination-page-count: 92    # walked as 92 pages of 100 = all 9,113 events
```

The shortfall was exactly this, down to the event. Trakt.tv reports 921 history items since 2022-08-24, and `/wp/v2/traktivity_event` on the site returned `x-wp-total: 921`.

## Testing instructions

`npm run test:php`. `tests/php/FullSyncTest.php` stands a fake Trakt.tv in front of the sync that paginates the way the real one does, defaulting to 100 when a request leaves `limit` out. Against the old code it fails with "The sync mixed page sizes: 100, 10", and 1,350 of the 1,500 fake events never get fetched.

On a real site: update, open the Trakt.tv settings screen, and start a synchronization. It works through 1,000 events per cron run, so a long history takes several. Watch the count in All Trakt.tv Events climb, or the pages left on the dashboard count down.
