### PR TITLE
Read one watch event through a single accessor

### DIFF
--- a/helpers.traktivity.php
+++ b/helpers.traktivity.php
@@ -54,12 +54,34 @@ function traktivity_empty_event_context(): array {
 }
 
 /**
+ * Read the first term attached to a post in a taxonomy.
+ *
+ * Every one of these taxonomies is many-to-many in the database, but the sync
+ * only ever attaches one show, one season and one episode to an event, so the
+ * first term is the term.
+ *
+ * @since 3.1.0
+ *
+ * @param int    $post_id  Post ID.
+ * @param string $taxonomy Taxonomy name.
+ *
+ * @return WP_Term|null First term, or null when there is none.
+ */
+function traktivity_first_term( int $post_id, string $taxonomy ) {
+	$terms = get_the_terms( $post_id, $taxonomy );
+
+	if ( is_wp_error( $terms ) || empty( $terms ) ) {
+		return null;
+	}
+
+	return $terms[0];
+}
+
+/**
  * Collect everything needed to describe one watch event.
  *
  * `type` is either 'tv' or 'movie'. `episode_code` is a composed 'S3E2' for
  * TV events that carry both numbers, and an empty string otherwise.
- *
- * Not yet implemented: returns the empty shape. See issue #684.
  *
  * @since 3.1.0
  *
@@ -68,9 +90,70 @@ function traktivity_empty_event_context(): array {
  * @return array Event context, in the shape of traktivity_empty_event_context().
  */
 function traktivity_get_event( int $post_id ): array {
-	unset( $post_id );
+	$context = traktivity_empty_event_context();
 
-	return traktivity_empty_event_context();
+	if ( $post_id < 1 || 'traktivity_event' !== get_post_type( $post_id ) ) {
+		return $context;
+	}
+
+	/*
+	 * Type comes from the meta rather than the trakt_type term. The sync names
+	 * that term with a translated string, so its slug is 'movie' on an English
+	 * site and something else entirely on a French one. The ID meta keys are
+	 * the same in every language.
+	 */
+	$is_movie = '' !== (string) get_post_meta( $post_id, 'trakt_movie_id', true );
+
+	$permalink = get_permalink( $post_id );
+	$year      = traktivity_first_term( $post_id, 'trakt_year' );
+
+	$context['type']        = $is_movie ? 'movie' : 'tv';
+	$context['title']       = (string) get_the_title( $post_id );
+	$context['permalink']   = is_string( $permalink ) ? $permalink : '';
+	$context['watched']     = (string) get_the_date( '', $post_id );
+	$context['watched_iso'] = (string) get_the_date( 'c', $post_id );
+	$context['runtime']     = (int) get_post_meta( $post_id, 'trakt_runtime', true );
+	$context['year']        = null === $year ? '' : $year->name;
+	$context['image_id']    = (int) get_post_thumbnail_id( $post_id );
+
+	if ( ! $is_movie ) {
+		$show = traktivity_first_term( $post_id, 'trakt_show' );
+
+		if ( null !== $show ) {
+			$show_link = get_term_link( $show );
+
+			$context['show_name'] = $show->name;
+			$context['show_link'] = is_wp_error( $show_link ) ? '' : $show_link;
+		}
+
+		$season  = traktivity_first_term( $post_id, 'trakt_season' );
+		$episode = traktivity_first_term( $post_id, 'trakt_episode' );
+
+		$context['season']  = null === $season ? 0 : (int) $season->name;
+		$context['episode'] = null === $episode ? 0 : (int) $episode->name;
+
+		/*
+		 * Both terms have to be there, rather than both being above zero.
+		 * Season 0 is where a show's specials live, so 'S0E5' is a real
+		 * episode code and testing for a positive number would drop it.
+		 */
+		if ( null !== $season && null !== $episode ) {
+			$context['episode_code'] = sprintf( 'S%dE%d', $context['season'], $context['episode'] );
+		}
+	}
+
+	/**
+	 * Filter the context describing a single watch event.
+	 *
+	 * Keys documented in traktivity_empty_event_context() are relied on by the
+	 * plugin's own blocks, so add to the array rather than removing from it.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param array $context Event context.
+	 * @param int   $post_id Event post ID.
+	 */
+	return (array) apply_filters( 'traktivity_event_context', $context, $post_id );
 }
 
 /**

--- a/tests/php/EventContextTest.php
+++ b/tests/php/EventContextTest.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * Tests for the event context accessor.
+ *
+ * @package Traktivity
+ */
+
+/**
+ * Reassembling one watch event from its taxonomies and meta.
+ */
+class EventContextTest extends WP_UnitTestCase {
+
+	/**
+	 * Build an event the way the sync would.
+	 *
+	 * @param array $meta       Post meta to attach.
+	 * @param array $taxonomies Terms to attach, keyed by taxonomy.
+	 * @param array $postarr    Overrides for wp_insert_post().
+	 *
+	 * @return int Post ID.
+	 */
+	private function make_event( array $meta = array(), array $taxonomies = array(), array $postarr = array() ) {
+		$post_id = self::factory()->post->create(
+			array_merge(
+				array(
+					'post_type'  => 'traktivity_event',
+					'post_title' => 'It Is All Good',
+					'post_date'  => '2026-03-04 20:00:00',
+				),
+				$postarr
+			)
+		);
+
+		foreach ( $meta as $key => $value ) {
+			update_post_meta( $post_id, $key, $value );
+		}
+
+		/*
+		 * Always an array. Passing the bare string "0" makes
+		 * wp_set_object_terms() treat the list as empty, because empty( "0" )
+		 * is true in PHP, and silently attach nothing. That is issue #702 on
+		 * the sync side; here it would just make the season 0 test lie.
+		 */
+		foreach ( $taxonomies as $taxonomy => $terms ) {
+			wp_set_object_terms( $post_id, (array) $terms, $taxonomy );
+		}
+
+		return $post_id;
+	}
+
+	/**
+	 * A TV event reassembles into something that identifies an episode.
+	 */
+	public function test_tv_event_is_described_in_full() {
+		$post_id = $this->make_event(
+			array(
+				'trakt_show_id' => 1234,
+				'trakt_runtime' => 60,
+			),
+			array(
+				'trakt_show'    => 'Some Show',
+				'trakt_season'  => '3',
+				'trakt_episode' => '2',
+				'trakt_year'    => '2023',
+			)
+		);
+
+		$event = traktivity_get_event( $post_id );
+
+		$this->assertSame( 'tv', $event['type'] );
+		$this->assertSame( 'It Is All Good', $event['title'] );
+		$this->assertSame( 'Some Show', $event['show_name'] );
+		$this->assertSame( 3, $event['season'] );
+		$this->assertSame( 2, $event['episode'] );
+		$this->assertSame( 'S3E2', $event['episode_code'] );
+		$this->assertSame( 60, $event['runtime'] );
+		$this->assertSame( '2023', $event['year'] );
+		$this->assertNotSame( '', $event['show_link'] );
+		$this->assertNotSame( '', $event['permalink'] );
+	}
+
+	/**
+	 * A movie carries no show, season or episode.
+	 */
+	public function test_movie_has_no_episode_fields() {
+		$post_id = $this->make_event(
+			array(
+				'trakt_movie_id' => 99,
+				'trakt_runtime'  => 105,
+			),
+			array( 'trakt_year' => '2019' ),
+			array( 'post_title' => 'A Film' )
+		);
+
+		$event = traktivity_get_event( $post_id );
+
+		$this->assertSame( 'movie', $event['type'] );
+		$this->assertSame( 'A Film', $event['title'] );
+		$this->assertSame( '', $event['show_name'] );
+		$this->assertSame( '', $event['show_link'] );
+		$this->assertSame( 0, $event['season'] );
+		$this->assertSame( 0, $event['episode'] );
+		$this->assertSame( '', $event['episode_code'] );
+		$this->assertSame( 105, $event['runtime'] );
+	}
+
+	/**
+	 * Type is read from the meta, not the translated trakt_type term.
+	 *
+	 * The sync names that term with esc_html__( 'Movie' ), so its slug is
+	 * 'movie' only on an English site. Detecting the type from the term would
+	 * silently mistype every event on a translated install, which is exactly
+	 * the sort of bug nobody running an English site would ever see.
+	 */
+	public function test_type_survives_a_translated_type_term() {
+		$post_id = $this->make_event(
+			array( 'trakt_movie_id' => 42 ),
+			array( 'trakt_type' => 'Filme' )
+		);
+
+		$this->assertSame( 'movie', traktivity_get_event( $post_id )['type'] );
+
+		$tv_id = $this->make_event(
+			array( 'trakt_show_id' => 43 ),
+			array(
+				'trakt_type' => 'Serie TV',
+				'trakt_show' => 'Another Show',
+			)
+		);
+
+		$this->assertSame( 'tv', traktivity_get_event( $tv_id )['type'] );
+	}
+
+	/**
+	 * A season 0 special still gets an episode code.
+	 *
+	 * Specials live in season 0, so testing that the season number is above
+	 * zero rather than that the term exists would drop the code for every one
+	 * of them.
+	 *
+	 * The sync does not currently manage to attach a season 0 term at all
+	 * (#702), so this covers the accessor rather than today's data. It should
+	 * keep passing once that is fixed, which is the point of writing it now.
+	 */
+	public function test_season_zero_special_keeps_its_code() {
+		$post_id = $this->make_event(
+			array( 'trakt_show_id' => 7 ),
+			array(
+				'trakt_show'    => 'Show With Specials',
+				'trakt_season'  => '0',
+				'trakt_episode' => '5',
+			)
+		);
+
+		$this->assertSame( 'S0E5', traktivity_get_event( $post_id )['episode_code'] );
+	}
+
+	/**
+	 * An event missing its season or episode gets no half-built code.
+	 */
+	public function test_partial_episode_data_produces_no_code() {
+		$post_id = $this->make_event(
+			array( 'trakt_show_id' => 8 ),
+			array(
+				'trakt_show'   => 'Half A Show',
+				'trakt_season' => '2',
+			)
+		);
+
+		$event = traktivity_get_event( $post_id );
+
+		$this->assertSame( 2, $event['season'] );
+		$this->assertSame( 0, $event['episode'] );
+		$this->assertSame( '', $event['episode_code'] );
+	}
+
+	/**
+	 * An event with no image reports 0 rather than false.
+	 */
+	public function test_missing_image_reports_zero() {
+		$post_id = $this->make_event( array( 'trakt_show_id' => 9 ) );
+
+		$this->assertSame( 0, traktivity_get_event( $post_id )['image_id'] );
+	}
+
+	/**
+	 * A post of another type gets the empty shape rather than a partial one.
+	 */
+	public function test_other_post_types_get_the_empty_shape() {
+		$post_id = self::factory()->post->create( array( 'post_title' => 'A blog post' ) );
+
+		$this->assertSame( traktivity_empty_event_context(), traktivity_get_event( $post_id ) );
+	}
+
+	/**
+	 * A post ID that does not exist is handled like any other miss.
+	 */
+	public function test_unknown_post_gets_the_empty_shape() {
+		$this->assertSame( traktivity_empty_event_context(), traktivity_get_event( 999999 ) );
+		$this->assertSame( traktivity_empty_event_context(), traktivity_get_event( 0 ) );
+	}
+
+	/**
+	 * The context is filterable.
+	 */
+	public function test_context_is_filterable() {
+		$post_id = $this->make_event( array( 'trakt_show_id' => 10 ) );
+
+		add_filter(
+			'traktivity_event_context',
+			static function ( $context ) {
+				$context['extra'] = 'added';
+				return $context;
+			}
+		);
+
+		$this->assertSame( 'added', traktivity_get_event( $post_id )['extra'] );
+	}
+}

--- a/tests/php/ListWidgetTest.php
+++ b/tests/php/ListWidgetTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Tests for the event list widget.
+ *
+ * @package Traktivity
+ */
+
+/**
+ * Episode details appended to widget titles.
+ */
+class ListWidgetTest extends WP_UnitTestCase {
+
+	/**
+	 * The widget under test.
+	 *
+	 * @var Traktivity_List_Widget
+	 */
+	private $widget;
+
+	/**
+	 * Stand up a widget instance.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->widget = new Traktivity_List_Widget();
+	}
+
+	/**
+	 * Build a TV event with the terms the widget needs.
+	 *
+	 * @param string $type_term Name to give the trakt_type term.
+	 *
+	 * @return int Post ID.
+	 */
+	private function make_tv_event( $type_term = 'TV Series' ) {
+		$post_id = self::factory()->post->create( array( 'post_type' => 'traktivity_event' ) );
+
+		update_post_meta( $post_id, 'trakt_show_id', 555 );
+		wp_set_object_terms( $post_id, array( $type_term ), 'trakt_type' );
+		wp_set_object_terms( $post_id, array( 'A Show' ), 'trakt_show' );
+		wp_set_object_terms( $post_id, array( '4' ), 'trakt_season' );
+		wp_set_object_terms( $post_id, array( '11' ), 'trakt_episode' );
+
+		return $post_id;
+	}
+
+	/**
+	 * A TV episode gets its show, season and episode appended.
+	 */
+	public function test_tv_episode_gets_its_details() {
+		$title = $this->widget->custom_tv_event_title( 'Episode name', $this->make_tv_event() );
+
+		$this->assertStringContainsString( 'episode-details', $title );
+		$this->assertStringContainsString( 'A Show', $title );
+		$this->assertStringContainsString( 'season 4', $title );
+		$this->assertStringContainsString( 'episode 11', $title );
+		$this->assertStringContainsString( 'Episode name', $title );
+	}
+
+	/**
+	 * Details are appended on a site where trakt_type is translated.
+	 *
+	 * The old implementation tested has_term( 'TV Series', 'trakt_type' ), and
+	 * the sync creates that term from a translated string, so every episode on
+	 * a non-English install silently lost its details here.
+	 */
+	public function test_details_survive_a_translated_type_term() {
+		$title = $this->widget->custom_tv_event_title( 'Episode name', $this->make_tv_event( 'Serie TV' ) );
+
+		$this->assertStringContainsString( 'A Show', $title );
+		$this->assertStringContainsString( 'season 4', $title );
+	}
+
+	/**
+	 * A movie is handed back untouched.
+	 */
+	public function test_movie_title_is_left_alone() {
+		$post_id = self::factory()->post->create( array( 'post_type' => 'traktivity_event' ) );
+		update_post_meta( $post_id, 'trakt_movie_id', 77 );
+
+		$this->assertSame( 'A Film', $this->widget->custom_tv_event_title( 'A Film', $post_id ) );
+	}
+
+	/**
+	 * An episode missing its numbers is handed back untouched.
+	 */
+	public function test_incomplete_episode_is_left_alone() {
+		$post_id = self::factory()->post->create( array( 'post_type' => 'traktivity_event' ) );
+		update_post_meta( $post_id, 'trakt_show_id', 556 );
+		wp_set_object_terms( $post_id, array( 'A Show' ), 'trakt_show' );
+
+		$this->assertSame( 'Episode name', $this->widget->custom_tv_event_title( 'Episode name', $post_id ) );
+	}
+}

--- a/widgets/list-events.php
+++ b/widgets/list-events.php
@@ -39,8 +39,12 @@ class Traktivity_List_Widget extends WP_Widget {
 			$widget_ops
 		);
 
-		// Customize event titles for TV series.
-		add_action( 'traktivity_list_widget_single_event_title', array( $this, 'custom_tv_event_title' ), 20, 2 );
+		/*
+		 * Customize event titles for TV series. Fired with apply_filters() at
+		 * the call site, so it registers as a filter; add_action() worked only
+		 * because the two share an implementation.
+		 */
+		add_filter( 'traktivity_list_widget_single_event_title', array( $this, 'custom_tv_event_title' ), 20, 2 );
 	}
 
 	/**
@@ -308,97 +312,57 @@ class Traktivity_List_Widget extends WP_Widget {
 
 	/**
 	 * Custom event title for TV episodes.
-	 * Episode titles often aren't really well known. When the event type is TV series,
+	 * Episode titles often aren't really well known. When the event is a TV episode,
 	 * we'll add a new div including the show title, as well as the season and episode numbers.
 	 *
 	 * @since 1.2.0
 	 *
-	 * @param string $event_title  HTML output for the event title.
-	 * @param int    $post_id Post ID.
+	 * @param string $event_title HTML output for the event title.
+	 * @param int    $post_id     Post ID.
+	 *
+	 * @return string Event title, with episode details appended when we have them.
 	 */
 	public function custom_tv_event_title( $event_title, $post_id ) {
-		if ( has_term( 'TV Series', 'trakt_type', $post_id ) ) {
-			// Show title.
-			$show_title_terms = get_the_terms( $post_id, 'trakt_show' );
-			if ( $show_title_terms && ! is_wp_error( $show_title_terms ) ) {
-				// We only want to keep one element.
-				$first_show = true;
-				foreach ( $show_title_terms as $term ) {
-					if ( $first_show ) {
-						$show_title = sprintf(
-							'<a href="%1$s">%2$s</a>',
-							esc_url( get_term_link( $term->term_id, 'trakt_show' ) ),
-							esc_html( $term->name )
-						);
-						// Other shows won't be the first ones, we won't need them.
-						$first_show = false;
-					}
-				}
-			} else {
-				$show_title = '';
-			}
+		$event = traktivity_get_event( (int) $post_id );
 
-			// Season number.
-			$show_season_terms = get_the_terms( $post_id, 'trakt_season' );
-			if ( $show_season_terms && ! is_wp_error( $show_season_terms ) ) {
-				// We only want to keep one element.
-				$first_season_num = true;
-				foreach ( $show_season_terms as $term ) {
-					if ( $first_season_num ) {
-						$season_number = $term->name;
-						// Other shows won't be the first ones, we won't need them.
-						$first_season_num = false;
-					}
-				}
-			} else {
-				$season_number = '';
-			}
-
-			// Episode number.
-			$show_episode_terms = get_the_terms( $post_id, 'trakt_episode' );
-			if ( $show_episode_terms && ! is_wp_error( $show_episode_terms ) ) {
-				// We only want to keep one element.
-				$first_episode_num = true;
-				foreach ( $show_episode_terms as $term ) {
-					if ( $first_episode_num ) {
-						$episode_number = $term->name;
-						// Other shows won't be the first ones, we won't need them.
-						$first_episode_num = false;
-					}
-				}
-			} else {
-				$episode_number = '';
-			}
-
-			// If we don't have extra info, don't display it.
-			if (
-				empty( $show_title )
-				|| empty( $season_number )
-				|| empty( $episode_number )
-			) {
-				return $event_title;
-			}
-
-			// Build our new event title, including extra info.
-			$event_title .= '<div class="episode-details">';
-
-			$event_title .= sprintf(
-				/* translators: additional informaton about each episode displayed in the widget listing recent watched TV shows. */
-				_x(
-					'%1$s, season %2$d, episode %3$d',
-					'1: Episode title. 2. Show title. 3. Season number. 4. Episode number.',
-					'traktivity'
-				),
-				$show_title,
-				absint( $season_number ),
-				absint( $episode_number )
-			);
-
-			$event_title .= '</div>';
-
-			return $event_title;
-		} else {
+		/*
+		 * This used to test has_term( 'TV Series', 'trakt_type' ) and walk the
+		 * show, season and episode taxonomies by hand. The term name is
+		 * translated when the sync creates it, so that test only ever matched
+		 * on an English site, and every episode on a translated install lost
+		 * its details here.
+		 */
+		if (
+			'tv' !== $event['type']
+			|| '' === $event['show_name']
+			|| '' === $event['show_link']
+			|| '' === $event['episode_code']
+		) {
 			return $event_title;
 		}
+
+		$show_title = sprintf(
+			'<a href="%1$s">%2$s</a>',
+			esc_url( $event['show_link'] ),
+			esc_html( $event['show_name'] )
+		);
+
+		$event_title .= '<div class="episode-details">';
+
+		$event_title .= sprintf(
+			/* translators: additional informaton about each episode displayed in the widget listing recent watched TV shows. */
+			_x(
+				'%1$s, season %2$d, episode %3$d',
+				'1: Episode title. 2. Show title. 3. Season number. 4. Episode number.',
+				'traktivity'
+			),
+			$show_title,
+			absint( $event['season'] ),
+			absint( $event['episode'] )
+		);
+
+		$event_title .= '</div>';
+
+		return $event_title;
 	}
 }


### PR DESCRIPTION
Fixes #684

## What it does

`traktivity_get_event( $post_id )` returns everything needed to describe one
watch event, in one call and always in the same shape. Before this, describing an
event meant knowing that the type lives in `trakt_type`, the show in
`trakt_show`, the season and episode in two more taxonomies, the year in a fifth,
and the runtime in post meta.

The widget's `custom_tv_event_title()` is refactored onto it, which takes about
eighty lines of hand-rolled term walking down to a handful.

## Rationale

Every block in this milestone reads event data, so this is the thing they all sit
on. Movies short-circuit before the show, season and episode lookups instead of
running four queries that return nothing, and every key is always present so
callers don't have to check before reading one.

Two bugs turned up while writing it.

**The type can't be read from `trakt_type`.** The sync names that term with
`esc_html__( 'Movie', 'traktivity' )` (`core.traktivity.php:536`), so its slug is
`movie` on an English site and something else on a translated one. The accessor
reads `trakt_movie_id` / `trakt_show_id` instead, which are the same in every
language.

The widget had exactly this bug: `has_term( 'TV Series', 'trakt_type', $post_id )`
only ever matched on an English install, so no episode on a translated site has
ever had its show and episode numbers appended. Moving it onto the accessor fixes
that, and there's a regression test for it.

**Season 0 is real.** Specials live there, so `S0E5` is a valid episode code. The
accessor builds the code when both terms exist rather than when both are above
zero, which a positive-number test would drop. Worth knowing that the sync
doesn't currently attach a season 0 term at all — that's #702, filed separately
while writing these tests. The accessor is written for the data we want, and its
test will keep passing once the sync is fixed.

One thing this deliberately doesn't do: the accessor returns the empty shape for
a post of the wrong type rather than `null` or a partial array, so a caller never
has to branch on the return before reading it.

## Also in here

`custom_tv_event_title()` was registered with `add_action()` while its call site
fires `apply_filters()` (`widgets/list-events.php:283`). That worked, because the
two share an implementation, but the callback returns a value and PHPStan flags
it the moment the return type is documented. It's a filter now.

## Usage

```php
$event = traktivity_get_event( $post_id );

if ( 'tv' === $event['type'] ) {
	printf(
		'%1$s %2$s',
		esc_html( $event['episode_code'] ), // "S3E2"
		esc_html( $event['title'] )
	);
}
```

`show_name` and `show_link` stay separate so a caller wanting a linked show name
can escape the parts individually. Add your own keys with the
`traktivity_event_context` filter.

## Testing

`composer run lint && composer run analyse` clean. PHPUnit is 88 passing, 1
incomplete, the incomplete one being the `traktivity_get_show_poster()` case
waiting on #687.

New coverage: TV and movie events, a translated `trakt_type` term, a season 0
special, an event missing its episode number, an event with no image, a post of
the wrong type, an unknown post ID, the filter, and four widget cases including
the translated-term regression.
