### PR TITLE
Compose event titles that say what was watched

### DIFF
--- a/helpers.traktivity.php
+++ b/helpers.traktivity.php
@@ -159,16 +159,13 @@ function traktivity_get_event( int $post_id ): array {
 /**
  * Compose a title that identifies what was watched.
  *
- * Episode titles mean nothing alone, so the show name and the episode code
- * are pulled back in from their separate taxonomies. Movies get their plain
- * title.
+ * Episode titles mean nothing alone, so the show name and the episode code are
+ * pulled back in from their separate taxonomies. Movies get their plain title.
  *
  * Always plain text, never markup, so there is one escaping rule rather than
  * one per argument: callers escape it. Anything wanting a linked show name
  * builds that itself from the `show_name` and `show_link` keys on
  * traktivity_get_event(), which are kept separate for exactly this reason.
- *
- * Not yet implemented: returns the plain post title. See issue #685.
  *
  * @since 3.1.0
  *
@@ -178,9 +175,52 @@ function traktivity_get_event( int $post_id ): array {
  * @return string Composed title, unescaped plain text.
  */
 function traktivity_get_event_title( int $post_id, bool $show_name = true ): string {
-	unset( $show_name );
+	$event = traktivity_get_event( $post_id );
 
-	return (string) get_the_title( $post_id );
+	if ( '' === $event['title'] ) {
+		return (string) get_the_title( $post_id );
+	}
+
+	/*
+	 * Built from whatever is actually there. An event missing its season term
+	 * still has a show worth naming, and one missing its show still has an
+	 * episode code worth printing, so each part is dropped on its own rather
+	 * than the whole thing falling back to the bare episode name.
+	 */
+	$prefix = array();
+
+	if ( $show_name && '' !== $event['show_name'] ) {
+		$prefix[] = $event['show_name'];
+	}
+
+	if ( '' !== $event['episode_code'] ) {
+		$prefix[] = $event['episode_code'];
+	}
+
+	if ( empty( $prefix ) ) {
+		return $event['title'];
+	}
+
+	$title = sprintf(
+		/* translators: 1: show name and/or episode code, e.g. "Some Show: S3E2". 2: episode title. */
+		_x( '%1$s: %2$s', 'Composed title for one watched episode', 'traktivity' ),
+		implode( ' ', $prefix ),
+		$event['title']
+	);
+
+	/**
+	 * Filter the composed title for one watch event.
+	 *
+	 * Plain text in, plain text out. Returning markup here breaks callers,
+	 * which escape the result on the way to the page.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param string $title   Composed title.
+	 * @param array  $event   Event context, from traktivity_get_event().
+	 * @param int    $post_id Event post ID.
+	 */
+	return (string) apply_filters( 'traktivity_event_title_text', $title, $event, $post_id );
 }
 
 /**

--- a/tests/php/EventTitleTest.php
+++ b/tests/php/EventTitleTest.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Tests for the composed event title.
+ *
+ * @package Traktivity
+ */
+
+/**
+ * Composing a title that identifies what was watched.
+ */
+class EventTitleTest extends WP_UnitTestCase {
+
+	/**
+	 * Build an event the way the sync would.
+	 *
+	 * @param array  $meta       Post meta to attach.
+	 * @param array  $taxonomies Terms to attach, keyed by taxonomy.
+	 * @param string $title      Post title.
+	 *
+	 * @return int Post ID.
+	 */
+	private function make_event( array $meta, array $taxonomies = array(), $title = 'Episode Name' ) {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'  => 'traktivity_event',
+				'post_title' => $title,
+			)
+		);
+
+		foreach ( $meta as $key => $value ) {
+			update_post_meta( $post_id, $key, $value );
+		}
+
+		// Always an array: a bare "0" reads as empty to wp_set_object_terms(). See #702.
+		foreach ( $taxonomies as $taxonomy => $terms ) {
+			wp_set_object_terms( $post_id, (array) $terms, $taxonomy );
+		}
+
+		return $post_id;
+	}
+
+	/**
+	 * A TV episode gets its show and episode code.
+	 */
+	public function test_tv_episode_is_identified() {
+		$post_id = $this->make_event(
+			array( 'trakt_show_id' => 1 ),
+			array(
+				'trakt_show'    => 'Some Show',
+				'trakt_season'  => '3',
+				'trakt_episode' => '2',
+			)
+		);
+
+		$this->assertSame( 'Some Show S3E2: Episode Name', traktivity_get_event_title( $post_id ) );
+	}
+
+	/**
+	 * The show name can be left out, for a listing that already names it.
+	 */
+	public function test_show_name_can_be_dropped() {
+		$post_id = $this->make_event(
+			array( 'trakt_show_id' => 2 ),
+			array(
+				'trakt_show'    => 'Some Show',
+				'trakt_season'  => '1',
+				'trakt_episode' => '4',
+			)
+		);
+
+		$this->assertSame( 'S1E4: Episode Name', traktivity_get_event_title( $post_id, false ) );
+	}
+
+	/**
+	 * A movie keeps its plain title, with nothing bolted on.
+	 */
+	public function test_movie_keeps_its_title() {
+		$post_id = $this->make_event( array( 'trakt_movie_id' => 3 ), array(), 'A Film' );
+
+		$this->assertSame( 'A Film', traktivity_get_event_title( $post_id ) );
+	}
+
+	/**
+	 * An episode with no season or episode terms still names its show.
+	 *
+	 * Each part is dropped on its own, so partial data degrades to something
+	 * useful rather than falling back to the bare episode name.
+	 */
+	public function test_missing_numbers_still_names_the_show() {
+		$post_id = $this->make_event(
+			array( 'trakt_show_id' => 4 ),
+			array( 'trakt_show' => 'Some Show' )
+		);
+
+		$this->assertSame( 'Some Show: Episode Name', traktivity_get_event_title( $post_id ) );
+	}
+
+	/**
+	 * An episode with no show still prints its episode code.
+	 */
+	public function test_missing_show_still_prints_the_code() {
+		$post_id = $this->make_event(
+			array( 'trakt_show_id' => 5 ),
+			array(
+				'trakt_season'  => '2',
+				'trakt_episode' => '7',
+			)
+		);
+
+		$this->assertSame( 'S2E7: Episode Name', traktivity_get_event_title( $post_id ) );
+	}
+
+	/**
+	 * An episode with neither falls back to the bare title, with no stray colon.
+	 */
+	public function test_no_extra_information_leaves_the_title_alone() {
+		$post_id = $this->make_event( array( 'trakt_show_id' => 6 ) );
+
+		$this->assertSame( 'Episode Name', traktivity_get_event_title( $post_id ) );
+	}
+
+	/**
+	 * A post of another type is handled without composing anything.
+	 */
+	public function test_other_post_types_get_their_own_title() {
+		$post_id = self::factory()->post->create( array( 'post_title' => 'A blog post' ) );
+
+		$this->assertSame( 'A blog post', traktivity_get_event_title( $post_id ) );
+	}
+
+	/**
+	 * A season 0 special is identified like any other episode.
+	 */
+	public function test_season_zero_special_is_identified() {
+		$post_id = $this->make_event(
+			array( 'trakt_show_id' => 7 ),
+			array(
+				'trakt_show'    => 'Some Show',
+				'trakt_season'  => '0',
+				'trakt_episode' => '3',
+			)
+		);
+
+		$this->assertSame( 'Some Show S0E3: Episode Name', traktivity_get_event_title( $post_id ) );
+	}
+
+	/**
+	 * The composed title is filterable.
+	 */
+	public function test_title_is_filterable() {
+		$post_id = $this->make_event(
+			array( 'trakt_show_id' => 8 ),
+			array( 'trakt_show' => 'Some Show' )
+		);
+
+		add_filter(
+			'traktivity_event_title_text',
+			static function ( $title, $event ) {
+				return $event['show_name'] . ' | ' . $title;
+			},
+			10,
+			2
+		);
+
+		$this->assertSame( 'Some Show | Some Show: Episode Name', traktivity_get_event_title( $post_id ) );
+	}
+
+	/**
+	 * Nothing here filters the_title.
+	 *
+	 * Composing titles site-wide would change the admin list, feeds and
+	 * anything else calling get_the_title(). That was decided against on #683,
+	 * so the helper and the block are the only ways in.
+	 */
+	public function test_the_title_is_left_untouched() {
+		$post_id = $this->make_event(
+			array( 'trakt_show_id' => 9 ),
+			array(
+				'trakt_show'    => 'Some Show',
+				'trakt_season'  => '1',
+				'trakt_episode' => '1',
+			)
+		);
+
+		$this->assertSame( 'Episode Name', get_the_title( $post_id ) );
+	}
+}


### PR DESCRIPTION
Fixes #685

## What it does

`traktivity_get_event_title( $post_id )` returns a title that identifies what was
watched. `Episode Name` becomes `Some Show S3E2: Episode Name`. Movies come back
untouched.

Built on `traktivity_get_event()`, so it doesn't walk the taxonomies again.

## Rationale

Each part is dropped independently rather than the whole thing falling back to
the bare episode name. An episode missing its season term still has a show worth
naming; one missing its show still has a code worth printing. With neither, the
title comes back as-is rather than carrying a stray colon.

Plain text only, always. Callers escape. Anything wanting a linked show name
builds it from the `show_name` and `show_link` keys the accessor already keeps
separate, so each part stays escapable on its own.

Pass `false` as the second argument to drop the show name, for a listing that
already names it once at the top.

**No `the_title` filter, and no option to add one.** That was decided on #683.
Filtering it globally would change the admin list table, the editor and
everything else calling `get_the_title()`, and the accepted consequence is that
feeds and search results keep showing bare episode names. There's a test
asserting `get_the_title()` stays untouched, so this doesn't get quietly added
later.

The composed string goes through `_x()` rather than being concatenated, so a
translator can move the parts around.

## Usage

```php
echo esc_html( traktivity_get_event_title( $post_id ) );
// "Some Show S3E2: Episode Name"

echo esc_html( traktivity_get_event_title( $post_id, false ) );
// "S3E2: Episode Name"
```

`traktivity_event_title_text` filters the result. Plain text in, plain text out;
returning markup there breaks callers, since they escape on the way to the page.

## Testing

`composer run lint && composer run analyse` clean. PHPUnit 98 passing, 1
incomplete (the `traktivity_get_show_poster()` case waiting on #687).

New coverage: a full TV episode, the show name dropped, a movie, an episode
missing its numbers, one missing its show, one with neither, a season 0 special,
a post of the wrong type, the filter, and `the_title` staying untouched.
