### PR TITLE
Build the Trakt.tv, IMDb and TMDb links for an event

### DIFF
--- a/helpers.traktivity.php
+++ b/helpers.traktivity.php
@@ -224,13 +224,43 @@ function traktivity_get_event_title( int $post_id, bool $show_name = true ): str
 }
 
 /**
+ * Build one external reference.
+ *
+ * Shared by the event and show link builders so a URL template lives in one
+ * place. IDs come from a third-party API, so they are encoded on the way into
+ * a URL whatever they turn out to contain.
+ *
+ * @since 3.1.0
+ *
+ * @param string $service Service key: 'trakt', 'imdb' or 'tmdb'.
+ * @param string $url     Full URL.
+ *
+ * @return array{label: string, url: string} One reference.
+ */
+function traktivity_build_link( string $service, string $url ): array {
+	$labels = array(
+		'trakt' => __( 'Trakt', 'traktivity' ),
+		'imdb'  => __( 'IMDb', 'traktivity' ),
+		'tmdb'  => __( 'TMDb', 'traktivity' ),
+	);
+
+	return array(
+		'label' => isset( $labels[ $service ] ) ? $labels[ $service ] : $service,
+		'url'   => $url,
+	);
+}
+
+/**
  * Build the external references stored against an event.
  *
  * Keyed by service ('trakt', 'imdb', 'tmdb'), each value an array with 'label'
  * and 'url'. A service with no stored ID is absent rather than present and
  * empty, so callers can iterate the result directly.
  *
- * Not yet implemented: returns an empty array. See issue #686.
+ * Which ID a service gets depends on the event type, and on how precise a link
+ * that service supports. IMDb has a page per episode, so TV events link
+ * straight to it. TMDb needs the season and episode numbers in the path to do
+ * the same, so it deep-links when they are known and falls back to the show.
  *
  * @since 3.1.0
  *
@@ -239,9 +269,56 @@ function traktivity_get_event_title( int $post_id, bool $show_name = true ): str
  * @return array<string, array{label: string, url: string}> External links.
  */
 function traktivity_get_event_links( int $post_id ): array {
-	unset( $post_id );
+	$event = traktivity_get_event( $post_id );
 
-	return array();
+	if ( '' === $event['type'] ) {
+		return array();
+	}
+
+	$is_movie = 'movie' === $event['type'];
+	$links    = array();
+
+	$trakt_id = (string) get_post_meta( $post_id, $is_movie ? 'trakt_movie_id' : 'trakt_show_id', true );
+	if ( '' !== $trakt_id ) {
+		$links['trakt'] = traktivity_build_link(
+			'trakt',
+			add_query_arg(
+				'id_type',
+				$is_movie ? 'movie' : 'show',
+				'https://trakt.tv/search/trakt/' . rawurlencode( $trakt_id )
+			)
+		);
+	}
+
+	$imdb_id = (string) get_post_meta( $post_id, $is_movie ? 'imdb_movie_id' : 'imdb_episode_id', true );
+	if ( '' !== $imdb_id ) {
+		$links['imdb'] = traktivity_build_link( 'imdb', 'https://www.imdb.com/title/' . rawurlencode( $imdb_id ) . '/' );
+	}
+
+	$tmdb_id = (string) get_post_meta( $post_id, $is_movie ? 'tmdb_movie_id' : 'tmdb_show_id', true );
+	if ( '' !== $tmdb_id ) {
+		$tmdb_url = 'https://www.themoviedb.org/' . ( $is_movie ? 'movie' : 'tv' ) . '/' . rawurlencode( $tmdb_id );
+
+		if ( ! $is_movie && '' !== $event['episode_code'] ) {
+			$tmdb_url .= sprintf( '/season/%1$d/episode/%2$d', $event['season'], $event['episode'] );
+		}
+
+		$links['tmdb'] = traktivity_build_link( 'tmdb', $tmdb_url );
+	}
+
+	/**
+	 * Filter the external references for one watch event.
+	 *
+	 * Entries are rendered as links, so anything added here needs a 'label'
+	 * and a 'url'.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param array $links   External references, keyed by service.
+	 * @param int   $post_id Event post ID.
+	 * @param array $event   Event context, from traktivity_get_event().
+	 */
+	return (array) apply_filters( 'traktivity_event_links', $links, $post_id, $event );
 }
 
 /**

--- a/tests/php/EventLinksTest.php
+++ b/tests/php/EventLinksTest.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Tests for the external reference builder.
+ *
+ * @package Traktivity
+ */
+
+/**
+ * Linking a watch event out to Trakt.tv, IMDb and TMDb.
+ */
+class EventLinksTest extends WP_UnitTestCase {
+
+	/**
+	 * Build an event the way the sync would.
+	 *
+	 * @param array $meta       Post meta to attach.
+	 * @param array $taxonomies Terms to attach, keyed by taxonomy.
+	 *
+	 * @return int Post ID.
+	 */
+	private function make_event( array $meta, array $taxonomies = array() ) {
+		$post_id = self::factory()->post->create( array( 'post_type' => 'traktivity_event' ) );
+
+		foreach ( $meta as $key => $value ) {
+			update_post_meta( $post_id, $key, $value );
+		}
+
+		// Always an array: a bare "0" reads as empty to wp_set_object_terms(). See #702.
+		foreach ( $taxonomies as $taxonomy => $terms ) {
+			wp_set_object_terms( $post_id, (array) $terms, $taxonomy );
+		}
+
+		return $post_id;
+	}
+
+	/**
+	 * A TV episode links out to all three services.
+	 */
+	public function test_tv_episode_links_to_every_service() {
+		$post_id = $this->make_event(
+			array(
+				'trakt_show_id'   => 111,
+				'imdb_episode_id' => 'tt1234567',
+				'tmdb_show_id'    => 222,
+			),
+			array( 'trakt_show' => 'Some Show' )
+		);
+
+		$links = traktivity_get_event_links( $post_id );
+
+		$this->assertSame( array( 'trakt', 'imdb', 'tmdb' ), array_keys( $links ) );
+		$this->assertStringContainsString( 'id_type=show', $links['trakt']['url'] );
+		$this->assertStringContainsString( '111', $links['trakt']['url'] );
+		$this->assertSame( 'https://www.imdb.com/title/tt1234567/', $links['imdb']['url'] );
+		$this->assertStringContainsString( '/tv/222', $links['tmdb']['url'] );
+	}
+
+	/**
+	 * A movie uses the movie IDs, not the show ones.
+	 */
+	public function test_movie_uses_the_movie_ids() {
+		$post_id = $this->make_event(
+			array(
+				'trakt_movie_id' => 333,
+				'imdb_movie_id'  => 'tt7654321',
+				'tmdb_movie_id'  => 444,
+			)
+		);
+
+		$links = traktivity_get_event_links( $post_id );
+
+		$this->assertStringContainsString( 'id_type=movie', $links['trakt']['url'] );
+		$this->assertSame( 'https://www.imdb.com/title/tt7654321/', $links['imdb']['url'] );
+		$this->assertSame( 'https://www.themoviedb.org/movie/444', $links['tmdb']['url'] );
+	}
+
+	/**
+	 * TMDb deep-links to the episode when the numbers are known.
+	 *
+	 * TMDb has a page per episode, but the path needs the season and episode
+	 * numbers, which live in taxonomies rather than in the stored IDs.
+	 */
+	public function test_tmdb_deep_links_to_the_episode() {
+		$post_id = $this->make_event(
+			array(
+				'trakt_show_id' => 1,
+				'tmdb_show_id'  => 555,
+			),
+			array(
+				'trakt_show'    => 'Some Show',
+				'trakt_season'  => '3',
+				'trakt_episode' => '2',
+			)
+		);
+
+		$this->assertSame(
+			'https://www.themoviedb.org/tv/555/season/3/episode/2',
+			traktivity_get_event_links( $post_id )['tmdb']['url']
+		);
+	}
+
+	/**
+	 * Without the numbers, TMDb falls back to the show.
+	 */
+	public function test_tmdb_falls_back_to_the_show() {
+		$post_id = $this->make_event(
+			array(
+				'trakt_show_id' => 1,
+				'tmdb_show_id'  => 666,
+			),
+			array( 'trakt_show' => 'Some Show' )
+		);
+
+		$this->assertSame(
+			'https://www.themoviedb.org/tv/666',
+			traktivity_get_event_links( $post_id )['tmdb']['url']
+		);
+	}
+
+	/**
+	 * A service with no stored ID is absent, not empty.
+	 *
+	 * Callers iterate the result straight into a list of links, so an entry
+	 * with an empty URL would render as a dead link.
+	 */
+	public function test_missing_ids_are_absent_rather_than_empty() {
+		$post_id = $this->make_event(
+			array( 'trakt_show_id' => 777 ),
+			array( 'trakt_show' => 'Some Show' )
+		);
+
+		$links = traktivity_get_event_links( $post_id );
+
+		$this->assertSame( array( 'trakt' ), array_keys( $links ) );
+		$this->assertArrayNotHasKey( 'imdb', $links );
+		$this->assertArrayNotHasKey( 'tmdb', $links );
+	}
+
+	/**
+	 * An event with no external IDs at all returns nothing.
+	 */
+	public function test_event_with_no_ids_returns_nothing() {
+		$post_id = self::factory()->post->create( array( 'post_type' => 'traktivity_event' ) );
+
+		$this->assertSame( array(), traktivity_get_event_links( $post_id ) );
+	}
+
+	/**
+	 * A post of another type returns nothing.
+	 */
+	public function test_other_post_types_return_nothing() {
+		$post_id = self::factory()->post->create();
+
+		$this->assertSame( array(), traktivity_get_event_links( $post_id ) );
+	}
+
+	/**
+	 * Every entry carries a label and a URL.
+	 */
+	public function test_entries_are_labelled() {
+		$post_id = $this->make_event( array( 'trakt_movie_id' => 888 ) );
+
+		$this->assertSame( array( 'label', 'url' ), array_keys( traktivity_get_event_links( $post_id )['trakt'] ) );
+		$this->assertSame( 'Trakt', traktivity_get_event_links( $post_id )['trakt']['label'] );
+	}
+
+	/**
+	 * An ID carrying URL-unsafe characters cannot break out of the path.
+	 *
+	 * These come from a third-party API, so they are encoded rather than
+	 * trusted.
+	 */
+	public function test_ids_are_encoded() {
+		$post_id = $this->make_event( array( 'trakt_movie_id' => 'a/b?c' ) );
+
+		$url = traktivity_get_event_links( $post_id )['trakt']['url'];
+
+		$this->assertStringContainsString( 'a%2Fb%3Fc', $url );
+	}
+
+	/**
+	 * The links are filterable.
+	 */
+	public function test_links_are_filterable() {
+		$post_id = $this->make_event( array( 'trakt_movie_id' => 999 ) );
+
+		add_filter(
+			'traktivity_event_links',
+			static function ( $links ) {
+				unset( $links['trakt'] );
+				$links['letterboxd'] = array(
+					'label' => 'Letterboxd',
+					'url'   => 'https://letterboxd.com/',
+				);
+				return $links;
+			}
+		);
+
+		$links = traktivity_get_event_links( $post_id );
+
+		$this->assertArrayNotHasKey( 'trakt', $links );
+		$this->assertSame( 'Letterboxd', $links['letterboxd']['label'] );
+	}
+}


### PR DESCRIPTION
Fixes #686

## What it does

`traktivity_get_event_links( $post_id )` returns the external references stored
against an event, keyed by service, each with a `label` and a `url`.

```php
array(
	'trakt' => array( 'label' => 'Trakt', 'url' => 'https://trakt.tv/search/trakt/111?id_type=show' ),
	'imdb'  => array( 'label' => 'IMDb',  'url' => 'https://www.imdb.com/title/tt1234567/' ),
	'tmdb'  => array( 'label' => 'TMDb',  'url' => 'https://www.themoviedb.org/tv/222/season/3/episode/2' ),
)
```

## Rationale

Four separate pieces of plugin knowledge were needed to build these by hand: that
the meta key depends on the event type, that TV events use `imdb_episode_id`
where movies use `imdb_movie_id`, the URL shape each service wants, and that
Trakt.tv needs an `id_type` argument that also depends on the type. A theme
author has no way of knowing any of it.

Some decisions worth flagging:

- **Absent, not empty.** A service with no stored ID doesn't appear in the
  result. Callers iterate this straight into a list of links, so an entry with an
  empty URL would render as a dead one.
- **TMDb deep-links to the episode.** It has a page per episode, but the path
  needs the season and episode numbers, which live in taxonomies rather than
  alongside the IDs. The builder uses both and falls back to the show page when
  either is missing.
- **IDs are encoded.** They come from a third-party API and go straight into a
  URL path. There's a test for an ID containing a slash and a question mark.
- Keeping the URL templates in one place means one edit when a service changes
  its scheme, which they do.

## Usage

```php
foreach ( traktivity_get_event_links( $post_id ) as $link ) {
	printf(
		'<a href="%1$s">%2$s</a>',
		esc_url( $link['url'] ),
		esc_html( $link['label'] )
	);
}
```

`traktivity_event_links` filters the result, so a site can add Letterboxd or drop
a service it doesn't want.

## Testing

`composer run lint && composer run analyse` clean. PHPUnit 108 passing, 1
incomplete (the `traktivity_get_show_poster()` case waiting on #687).

New coverage: a TV episode hitting all three services, a movie using the movie
IDs, the TMDb episode deep link and its fallback, partial IDs, an event with no
IDs at all, a post of the wrong type, labelling, ID encoding, and the filter.
