### PR TITLE
Register the show term meta, and read it through accessors

### DIFF
--- a/helpers.traktivity.php
+++ b/helpers.traktivity.php
@@ -322,6 +322,94 @@ function traktivity_get_event_links( int $post_id ): array {
 }
 
 /**
+ * Register the term meta the sync stores against each show.
+ *
+ * Registering it puts the values in the REST API and gives them a schema, so
+ * a block editor or an external client can read a show the same way the
+ * plugin's own blocks do. The sync wrote all of this long before it was
+ * registered, so these describe existing data rather than introducing it.
+ *
+ * @since 3.1.0
+ */
+function traktivity_register_show_meta(): void {
+	register_term_meta(
+		'trakt_show',
+		'show_runtime',
+		array(
+			'type'              => 'integer',
+			'description'       => __( 'Total number of minutes logged against this show.', 'traktivity' ),
+			'single'            => true,
+			'default'           => 0,
+			'show_in_rest'      => true,
+			'sanitize_callback' => 'absint',
+			'auth_callback'     => '__return_false',
+		)
+	);
+
+	register_term_meta(
+		'trakt_show',
+		'show_network',
+		array(
+			'type'              => 'string',
+			'description'       => __( 'Network the show airs on.', 'traktivity' ),
+			'single'            => true,
+			'default'           => '',
+			'show_in_rest'      => true,
+			'sanitize_callback' => 'sanitize_text_field',
+			'auth_callback'     => '__return_false',
+		)
+	);
+
+	register_term_meta(
+		'trakt_show',
+		'show_poster',
+		array(
+			'type'          => 'object',
+			'description'   => __( 'Image for the show, as stored by the sync.', 'traktivity' ),
+			'single'        => true,
+			'show_in_rest'  => array(
+				'schema' => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+					'properties'           => array(
+						'id'  => array( 'type' => 'integer' ),
+						'url' => array(
+							'type'   => 'string',
+							'format' => 'uri',
+						),
+						'alt' => array( 'type' => 'string' ),
+					),
+				),
+			),
+			'auth_callback' => '__return_false',
+		)
+	);
+
+	register_term_meta(
+		'trakt_show',
+		'show_external_ids',
+		array(
+			'type'          => 'object',
+			'description'   => __( 'Trakt.tv, IMDb and TMDb IDs for the show.', 'traktivity' ),
+			'single'        => true,
+			'show_in_rest'  => array(
+				'schema' => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+					'properties'           => array(
+						'trakt' => array( 'type' => array( 'integer', 'string' ) ),
+						'imdb'  => array( 'type' => 'string' ),
+						'tmdb'  => array( 'type' => array( 'integer', 'string' ) ),
+					),
+				),
+			),
+			'auth_callback' => '__return_false',
+		)
+	);
+}
+add_action( 'init', 'traktivity_register_show_meta' );
+
+/**
  * Read the image stored against a show.
  *
  * Despite the meta key, this is a 16:9 still from TMDb rather than a 2:3
@@ -330,27 +418,36 @@ function traktivity_get_event_links( int $post_id ): array {
  * Returns an empty array when the show has no image, so callers can test the
  * result rather than picking through the stored value's shape.
  *
- * Not yet implemented: returns an empty array. See issue #687.
- *
  * @since 3.1.0
  *
  * @param int $term_id trakt_show term ID.
  *
  * @return array Empty when the show has no image. Otherwise an 'id' attachment
- *               ID, a 'url' and an 'alt' string, in that order. The shape is
- *               pinned by tests/php/ContractsTest.php rather than by this
- *               annotation, which stays loose while the body is a stub.
+ *               ID, a 'url' and an 'alt' string, in that order.
  */
 function traktivity_get_show_poster( int $term_id ): array {
-	unset( $term_id );
+	$poster = get_term_meta( $term_id, 'show_poster', true );
 
-	return array();
+	/*
+	 * The sync stores whatever sideload_image() handed back, which is an empty
+	 * array when the download failed and can be a partial one when the
+	 * attachment was made but the URL lookup came back empty. Normalising here
+	 * means callers go straight to $poster['id'] rather than each repeating
+	 * this.
+	 */
+	if ( ! is_array( $poster ) || empty( $poster['id'] ) ) {
+		return array();
+	}
+
+	return array(
+		'id'  => (int) $poster['id'],
+		'url' => isset( $poster['url'] ) ? (string) $poster['url'] : '',
+		'alt' => isset( $poster['alt'] ) ? (string) $poster['alt'] : '',
+	);
 }
 
 /**
  * Read the network a show airs on.
- *
- * Not yet implemented: returns an empty string. See issue #687.
  *
  * @since 3.1.0
  *
@@ -359,15 +456,11 @@ function traktivity_get_show_poster( int $term_id ): array {
  * @return string Network name, or an empty string.
  */
 function traktivity_get_show_network( int $term_id ): string {
-	unset( $term_id );
-
-	return '';
+	return (string) get_term_meta( $term_id, 'show_network', true );
 }
 
 /**
  * Read the total time logged against a show, in minutes.
- *
- * Not yet implemented: returns 0. See issue #687.
  *
  * @since 3.1.0
  *
@@ -376,17 +469,14 @@ function traktivity_get_show_network( int $term_id ): string {
  * @return int Minutes watched.
  */
 function traktivity_get_show_runtime( int $term_id ): int {
-	unset( $term_id );
-
-	return 0;
+	return (int) get_term_meta( $term_id, 'show_runtime', true );
 }
 
 /**
  * Build the external references stored against a show.
  *
- * Same shape as traktivity_get_event_links().
- *
- * Not yet implemented: returns an empty array. See issue #687.
+ * Same shape as traktivity_get_event_links(). These always point at the show
+ * rather than at an episode, since a term has no episode to be precise about.
  *
  * @since 3.1.0
  *
@@ -395,7 +485,36 @@ function traktivity_get_show_runtime( int $term_id ): int {
  * @return array<string, array{label: string, url: string}> External links.
  */
 function traktivity_get_show_links( int $term_id ): array {
-	unset( $term_id );
+	$ids = get_term_meta( $term_id, 'show_external_ids', true );
 
-	return array();
+	if ( ! is_array( $ids ) ) {
+		return array();
+	}
+
+	$links = array();
+
+	if ( ! empty( $ids['trakt'] ) ) {
+		$links['trakt'] = traktivity_build_link(
+			'trakt',
+			add_query_arg( 'id_type', 'show', 'https://trakt.tv/search/trakt/' . rawurlencode( (string) $ids['trakt'] ) )
+		);
+	}
+
+	if ( ! empty( $ids['imdb'] ) ) {
+		$links['imdb'] = traktivity_build_link( 'imdb', 'https://www.imdb.com/title/' . rawurlencode( (string) $ids['imdb'] ) . '/' );
+	}
+
+	if ( ! empty( $ids['tmdb'] ) ) {
+		$links['tmdb'] = traktivity_build_link( 'tmdb', 'https://www.themoviedb.org/tv/' . rawurlencode( (string) $ids['tmdb'] ) );
+	}
+
+	/**
+	 * Filter the external references for one show.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param array $links   External references, keyed by service.
+	 * @param int   $term_id trakt_show term ID.
+	 */
+	return (array) apply_filters( 'traktivity_show_links', $links, $term_id );
 }

--- a/tests/php/ContractsTest.php
+++ b/tests/php/ContractsTest.php
@@ -169,16 +169,21 @@ class ContractsTest extends WP_UnitTestCase {
 	 *
 	 * Callers test the array rather than picking through the stored value, so
 	 * a partial result would push that shape-checking back out to them.
-	 *
-	 * Marked incomplete rather than quietly passing: the accessor is still a
-	 * stub that only ever returns the empty case, which
-	 * test_show_accessors_handle_a_missing_term() covers. Issue #687 fills the
-	 * function in and has to extend this to a show that has an image.
 	 */
 	public function test_show_poster_populated_shape() {
-		$this->markTestIncomplete(
-			'Needs issue #687. Expected keys, in order: id, url, alt.'
+		$term = self::factory()->term->create_and_get( array( 'taxonomy' => 'trakt_show' ) );
+
+		update_term_meta(
+			$term->term_id,
+			'show_poster',
+			array(
+				'id'  => 12,
+				'url' => 'https://example.com/still.jpg',
+				'alt' => 'Some Show',
+			)
 		);
+
+		$this->assertSame( array( 'id', 'url', 'alt' ), array_keys( traktivity_get_show_poster( $term->term_id ) ) );
 	}
 
 	/**

--- a/tests/php/ShowMetaTest.php
+++ b/tests/php/ShowMetaTest.php
@@ -1,0 +1,247 @@
+<?php
+/**
+ * Tests for the show term meta accessors.
+ *
+ * @package Traktivity
+ */
+
+/**
+ * Reading what the sync stores against each show.
+ */
+class ShowMetaTest extends WP_UnitTestCase {
+
+	/**
+	 * Re-register the show meta.
+	 *
+	 * WP_UnitTestCase::tear_down() calls unregister_all_meta_keys(), so
+	 * whatever the bootstrap's init registered is gone by the time any test
+	 * after the first one runs. Registering again here tests the function
+	 * rather than the harness; test_registration_is_hooked() covers the wiring
+	 * that gets it called on a real site.
+	 */
+	public function set_up() {
+		parent::set_up();
+		traktivity_register_show_meta();
+	}
+
+	/**
+	 * The registration runs on init, so a real site gets it.
+	 */
+	public function test_registration_is_hooked() {
+		$this->assertNotFalse( has_action( 'init', 'traktivity_register_show_meta' ) );
+	}
+
+	/**
+	 * Create a show term.
+	 *
+	 * @param array $meta Term meta to attach.
+	 *
+	 * @return int Term ID.
+	 */
+	private function make_show( array $meta = array() ) {
+		$term = self::factory()->term->create_and_get(
+			array(
+				'taxonomy' => 'trakt_show',
+				'name'     => 'Some Show',
+			)
+		);
+
+		foreach ( $meta as $key => $value ) {
+			update_term_meta( $term->term_id, $key, $value );
+		}
+
+		return $term->term_id;
+	}
+
+	/**
+	 * All four keys are registered, so they reach the REST API with a schema.
+	 *
+	 * @dataProvider data_registered_keys
+	 *
+	 * @param string $key Meta key.
+	 */
+	public function test_meta_is_registered( $key ) {
+		$registered = get_registered_meta_keys( 'term', 'trakt_show' );
+
+		$this->assertArrayHasKey( $key, $registered );
+		$this->assertTrue( $registered[ $key ]['show_in_rest'] || is_array( $registered[ $key ]['show_in_rest'] ) );
+	}
+
+	/**
+	 * The meta keys the sync writes.
+	 *
+	 * @return array<string, array{string}>
+	 */
+	public function data_registered_keys() {
+		return array(
+			'runtime'      => array( 'show_runtime' ),
+			'network'      => array( 'show_network' ),
+			'poster'       => array( 'show_poster' ),
+			'external ids' => array( 'show_external_ids' ),
+		);
+	}
+
+	/**
+	 * A stored image comes back normalised, in a fixed key order.
+	 */
+	public function test_poster_is_normalised() {
+		$term_id = $this->make_show(
+			array(
+				'show_poster' => array(
+					'id'  => '42',
+					'url' => 'https://example.com/still.jpg',
+					'alt' => 'Some Show',
+				),
+			)
+		);
+
+		$poster = traktivity_get_show_poster( $term_id );
+
+		$this->assertSame( array( 'id', 'url', 'alt' ), array_keys( $poster ) );
+		$this->assertSame( 42, $poster['id'] );
+		$this->assertSame( 'https://example.com/still.jpg', $poster['url'] );
+	}
+
+	/**
+	 * A partial stored image still comes back whole.
+	 *
+	 * The sync stores whatever the sideload returned, and that can be an
+	 * attachment with no URL if the lookup came back empty. Normalising here
+	 * saves every caller from repeating the shape check.
+	 */
+	public function test_partial_poster_is_filled_in() {
+		$term_id = $this->make_show( array( 'show_poster' => array( 'id' => 7 ) ) );
+
+		$this->assertSame(
+			array(
+				'id'  => 7,
+				'url' => '',
+				'alt' => '',
+			),
+			traktivity_get_show_poster( $term_id )
+		);
+	}
+
+	/**
+	 * A show with no image, or a badly stored one, reports empty.
+	 *
+	 * @dataProvider data_empty_posters
+	 *
+	 * @param mixed $stored What the sync left behind.
+	 */
+	public function test_missing_poster_reports_empty( $stored ) {
+		$term_id = $this->make_show();
+
+		if ( null !== $stored ) {
+			update_term_meta( $term_id, 'show_poster', $stored );
+		}
+
+		$this->assertSame( array(), traktivity_get_show_poster( $term_id ) );
+	}
+
+	/**
+	 * Stored values that should all read as "no image".
+	 *
+	 * @return array<string, array{mixed}>
+	 */
+	public function data_empty_posters() {
+		return array(
+			'nothing stored' => array( null ),
+			'empty array'    => array( array() ),
+			'no id'          => array( array( 'url' => 'https://example.com/x.jpg' ) ),
+			'zero id'        => array( array( 'id' => 0 ) ),
+		);
+	}
+
+	/**
+	 * Network and runtime read back as the types callers expect.
+	 */
+	public function test_network_and_runtime() {
+		$term_id = $this->make_show(
+			array(
+				'show_network' => 'Some Network',
+				'show_runtime' => '480',
+			)
+		);
+
+		$this->assertSame( 'Some Network', traktivity_get_show_network( $term_id ) );
+		$this->assertSame( 480, traktivity_get_show_runtime( $term_id ) );
+	}
+
+	/**
+	 * A show with nothing stored reports empty rather than warning.
+	 */
+	public function test_bare_show_reports_empty() {
+		$term_id = $this->make_show();
+
+		$this->assertSame( '', traktivity_get_show_network( $term_id ) );
+		$this->assertSame( 0, traktivity_get_show_runtime( $term_id ) );
+		$this->assertSame( array(), traktivity_get_show_poster( $term_id ) );
+		$this->assertSame( array(), traktivity_get_show_links( $term_id ) );
+	}
+
+	/**
+	 * A term that does not exist is handled like any other miss.
+	 */
+	public function test_unknown_term_reports_empty() {
+		$this->assertSame( '', traktivity_get_show_network( 999999 ) );
+		$this->assertSame( 0, traktivity_get_show_runtime( 999999 ) );
+		$this->assertSame( array(), traktivity_get_show_poster( 999999 ) );
+		$this->assertSame( array(), traktivity_get_show_links( 999999 ) );
+	}
+
+	/**
+	 * Show links point at the show on each service.
+	 */
+	public function test_show_links() {
+		$term_id = $this->make_show(
+			array(
+				'show_external_ids' => array(
+					'trakt' => 111,
+					'imdb'  => 'tt1234567',
+					'tmdb'  => 222,
+				),
+			)
+		);
+
+		$links = traktivity_get_show_links( $term_id );
+
+		$this->assertSame( array( 'trakt', 'imdb', 'tmdb' ), array_keys( $links ) );
+		$this->assertStringContainsString( 'id_type=show', $links['trakt']['url'] );
+		$this->assertSame( 'https://www.imdb.com/title/tt1234567/', $links['imdb']['url'] );
+		$this->assertSame( 'https://www.themoviedb.org/tv/222', $links['tmdb']['url'] );
+	}
+
+	/**
+	 * A service with nothing stored is absent rather than empty.
+	 */
+	public function test_partial_show_links() {
+		$term_id = $this->make_show(
+			array(
+				'show_external_ids' => array(
+					'trakt' => 333,
+					'imdb'  => '',
+				),
+			)
+		);
+
+		$this->assertSame( array( 'trakt' ), array_keys( traktivity_get_show_links( $term_id ) ) );
+	}
+
+	/**
+	 * Show links are filterable.
+	 */
+	public function test_show_links_are_filterable() {
+		$term_id = $this->make_show( array( 'show_external_ids' => array( 'trakt' => 444 ) ) );
+
+		add_filter(
+			'traktivity_show_links',
+			static function ( $links ) {
+				$links['trakt']['label'] = 'Trakt.tv';
+				return $links;
+			}
+		);
+
+		$this->assertSame( 'Trakt.tv', traktivity_get_show_links( $term_id )['trakt']['label'] );
+	}
+}


### PR DESCRIPTION
Fixes #687

## What it does

Registers the four term meta keys the sync writes against each show, and adds an
accessor for each:

```php
traktivity_get_show_poster( $term_id );   // normalised array, or empty
traktivity_get_show_network( $term_id );
traktivity_get_show_runtime( $term_id );  // minutes
traktivity_get_show_links( $term_id );    // same shape as the event links
```

Registering them puts `show_runtime`, `show_network`, `show_poster` and
`show_external_ids` in the REST API with a schema, so `/wp-json/wp/v2/trakt_show`
now describes a show rather than just naming it.

## Rationale

The sync has written all four of these since long before this PR. None was
registered, so it was effectively private storage that themes and blocks needed
to read anyway.

`show_poster` is the one that most needed an accessor. It's an array, and reading
it raw means defending against it being a string, an empty value, or an array
missing the key you wanted. `traktivity_get_show_poster()` does that once and
always returns the same three keys in the same order, so callers go straight to
`$poster['id']`. Partial stored values get filled in rather than passed through.

Two things worth flagging:

- **The image is a 16:9 still, not a 2:3 poster**, whatever `show_poster`
  suggests. It's documented on the accessor, because anything rendering it in a
  portrait frame crops faces off. #694 and #696 both need to know.
- **`auth_callback` returns false.** This is sync output, not something a user
  should be editing over the API, so it's readable but not writable there.

## A note on the test

`test_meta_is_registered` calls `traktivity_register_show_meta()` in `set_up()`
rather than relying on the bootstrap. `WP_UnitTestCase::tear_down()` calls
`unregister_all_meta_keys()`, so whatever `init` registered is gone by the second
test in a run, and asserting against it would have been testing the harness.
A separate `test_registration_is_hooked()` covers the `init` wiring that a real
site depends on. Verified by hand against a running install:

```
$ wp eval 'echo implode( ",", array_keys( get_registered_meta_keys( "term", "trakt_show" ) ) );'
show_runtime,show_network,show_poster,show_external_ids
```

## Also in here

The contract test left incomplete by the wave 0 groundwork is now filled in,
since there's finally an implementation able to return a populated image. PHPUnit
reports no incomplete tests for the first time in this milestone.

## Testing

`composer run lint && composer run analyse` clean. PHPUnit 125 passing, 270
assertions, nothing incomplete.

New coverage: all four keys registering, the init wiring, a normalised image, a
partial one filled in, four flavours of missing image, network and runtime types,
a bare show, an unknown term ID, show links, partial show links, and the filter.
