### PR TITLE
Report the figures a site owner would want, and stop the total drifting

### DIFF
--- a/admin.traktivity.php
+++ b/admin.traktivity.php
@@ -116,7 +116,7 @@ function traktivity_dashboard_scripts( $hook ) {
 	);
 
 	$options = (array) get_option( 'traktivity' );
-	$stats   = (array) get_option( 'traktivity_stats' );
+	$summary = Traktivity_Stats::get_summary();
 
 	/*
 	 * Data only. Every user-facing string lives in the JavaScript, wrapped in
@@ -135,7 +135,7 @@ function traktivity_dashboard_scripts( $hook ) {
 		 * Formatted here rather than in JavaScript: turning a minute count
 		 * into "3 days, 4 hours" needs _n() for each unit.
 		 */
-		'totalTimeWatched' => isset( $stats['total_time_watched'] ) ? Traktivity_Stats::convert_time( $stats['total_time_watched'] ) : '',
+		'totalTimeWatched' => $summary['runtime'],
 	);
 
 	/*

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
   "scripts": {
     "lint": "phpcs",
     "lint:fix": "phpcbf",
-    "analyse": "phpstan analyse --memory-limit=1G",
+    "analyse": "phpstan analyse --memory-limit=2G",
     "test": "phpunit"
   }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -14,3 +14,8 @@ parameters:
 			- build/*
 	bootstrapFiles:
 		- tests/phpstan/bootstrap.php
+	# PHPStan sizes its worker pool from the CPU count, and on a CI runner that
+	# put enough workers in flight to exhaust the memory limit mid-analysis.
+	# The plugin is small enough that two workers cost no real wall-clock time.
+	parallel:
+		maximumNumberOfProcesses: 2

--- a/stats.traktivity.php
+++ b/stats.traktivity.php
@@ -127,36 +127,211 @@ class Traktivity_Stats {
 	 *
 	 * @return array{
 	 *     minutes: int, hours: int, runtime: string, entries: int,
-	 *     episodes: int, films: int, shows: int, since: string
+	 *     episodes: int, films: int, shows: int, since: string, since_iso: string
 	 * } Empty summary.
 	 */
 	public static function empty_summary() {
 		return array(
-			'minutes'  => 0,
-			'hours'    => 0,
-			'runtime'  => '',
-			'entries'  => 0,
-			'episodes' => 0,
-			'films'    => 0,
-			'shows'    => 0,
-			'since'    => '',
+			'minutes'   => 0,
+			'hours'     => 0,
+			'runtime'   => '',
+			'entries'   => 0,
+			'episodes'  => 0,
+			'films'     => 0,
+			'shows'     => 0,
+			'since'     => '',
+			'since_iso' => '',
 		);
+	}
+
+	/**
+	 * Name of the transient holding the cached summary.
+	 *
+	 * @var string
+	 */
+	const SUMMARY_TRANSIENT = 'traktivity_stats_summary';
+
+	/**
+	 * Whether the cache has already been dropped this request.
+	 *
+	 * A sync inserts hundreds of events in one request, each firing save_post.
+	 * Without this, every one of them would drop the cache and force the
+	 * running total to be recounted.
+	 *
+	 * @var bool
+	 */
+	private static $flushed_this_request = false;
+
+	/**
+	 * Count published events matching an ID meta key.
+	 *
+	 * Counting through the trakt_type taxonomy looks tempting and is wrong:
+	 * the sync names those terms with a translated string, so the 'movie' slug
+	 * only exists on an English site. The ID meta keys are the same in every
+	 * language, and match how traktivity_get_event() decides an event's type,
+	 * so the counts here agree with what a block renders.
+	 *
+	 * @since 3.1.0
+	 *
+	 * Counting is a plain query rather than wp_count_posts(), which reads a
+	 * cache that is not reliably dropped when a post is deleted: right after
+	 * wp_delete_post() it still reports the old total, while the query below
+	 * reports the real one. Since the figures here are cached for half a day
+	 * anyway, there is nothing to gain by reading a stale cache faster.
+	 *
+	 * @param string $meta_key Meta key that must exist, or an empty string to
+	 *                         count every published event.
+	 *
+	 * @return int Number of published events.
+	 */
+	private static function count_events( $meta_key = '' ) {
+		$args = array(
+			'post_type'              => 'traktivity_event',
+			'post_status'            => 'publish',
+			'posts_per_page'         => 1,
+			'fields'                 => 'ids',
+			'ignore_sticky_posts'    => true,
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+		);
+
+		if ( '' !== $meta_key ) {
+			$args['meta_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- One indexed meta key, and the result is cached for half a day.
+				array(
+					'key'     => $meta_key,
+					'compare' => 'EXISTS',
+				),
+			);
+		}
+
+		$query = new WP_Query( $args );
+
+		return (int) $query->found_posts;
 	}
 
 	/**
 	 * Headline figures for everything logged.
 	 *
-	 * `runtime` is the `convert_time()` string, ready to print. `since` is the
-	 * date of the oldest event, formatted for display.
+	 * `runtime` is the convert_time() string, ready to print. `since` is the
+	 * date of the oldest event in the site's own date format, with `since_iso`
+	 * alongside it for anything that needs to reformat or sort.
 	 *
-	 * Not yet implemented: returns the empty shape. See issue #688.
+	 * These change only when a sync runs, so the whole set is cached rather
+	 * than recomputed per request.
 	 *
 	 * @since 3.1.0
 	 *
 	 * @return array Summary, in the shape of empty_summary().
 	 */
 	public static function get_summary() {
-		return self::empty_summary();
+		$cached = get_transient( self::SUMMARY_TRANSIENT );
+
+		if ( is_array( $cached ) ) {
+			return $cached;
+		}
+
+		$minutes = self::total_time_watched();
+		$shows   = wp_count_terms(
+			array(
+				'taxonomy'   => 'trakt_show',
+				'hide_empty' => true,
+			)
+		);
+
+		$oldest = get_posts(
+			array(
+				'post_type'      => 'traktivity_event',
+				'post_status'    => 'publish',
+				'posts_per_page' => 1,
+				'orderby'        => 'date',
+				'order'          => 'ASC',
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+			)
+		);
+
+		$summary = array(
+			'minutes'   => $minutes,
+			'hours'     => (int) floor( $minutes / 60 ),
+			'runtime'   => self::convert_time( $minutes ),
+			'entries'   => self::count_events(),
+			'episodes'  => self::count_events( 'trakt_show_id' ),
+			'films'     => self::count_events( 'trakt_movie_id' ),
+			'shows'     => is_wp_error( $shows ) ? 0 : (int) $shows,
+			'since'     => empty( $oldest ) ? '' : (string) get_the_date( '', $oldest[0] ),
+			'since_iso' => empty( $oldest ) ? '' : (string) get_the_date( 'c', $oldest[0] ),
+		);
+
+		/**
+		 * Filter the headline figures for the site.
+		 *
+		 * Keys documented in empty_summary() are read by the plugin's own
+		 * blocks, so add to the array rather than removing from it.
+		 *
+		 * @since 3.1.0
+		 *
+		 * @param array $summary Stats summary.
+		 */
+		$summary = (array) apply_filters( 'traktivity_stats_summary', $summary );
+
+		set_transient( self::SUMMARY_TRANSIENT, $summary, 12 * HOUR_IN_SECONDS );
+
+		return $summary;
+	}
+
+	/**
+	 * Drop the cached figures so the next read recounts.
+	 *
+	 * The running total is reset rather than adjusted. Adjusting it means
+	 * getting every path right forever, and a counter that is only ever nudged
+	 * drifts as soon as one path is missed; deleting an event used to do
+	 * exactly that, with no way to force a recount short of deleting the
+	 * option by hand. A recount is one indexed query.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param bool $force Flush again even if this request already has.
+	 */
+	public static function flush( $force = false ) {
+		if ( self::$flushed_this_request && ! $force ) {
+			return;
+		}
+
+		self::$flushed_this_request = true;
+
+		delete_transient( self::SUMMARY_TRANSIENT );
+
+		$stats = get_option( 'traktivity_stats' );
+
+		if ( is_array( $stats ) && isset( $stats['total_time_watched'] ) ) {
+			unset( $stats['total_time_watched'] );
+			update_option( 'traktivity_stats', $stats );
+		}
+	}
+
+	/**
+	 * Reset the once-per-request guard.
+	 *
+	 * Tests only: PHPUnit runs many requests' worth of work in one process, so
+	 * without this the second flush in a suite would be a no-op.
+	 *
+	 * @since 3.1.0
+	 */
+	public static function reset_flush_guard() {
+		self::$flushed_this_request = false;
+	}
+
+	/**
+	 * Drop the cached figures when an event is added, changed or removed.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public static function flush_on_event_change( $post_id ) {
+		if ( 'traktivity_event' === get_post_type( $post_id ) ) {
+			self::flush();
+		}
 	}
 
 	/**
@@ -216,3 +391,6 @@ class Traktivity_Stats {
 		return 0;
 	}
 }
+
+add_action( 'save_post', array( 'Traktivity_Stats', 'flush_on_event_change' ) );
+add_action( 'deleted_post', array( 'Traktivity_Stats', 'flush_on_event_change' ) );

--- a/tests/php/ContractsTest.php
+++ b/tests/php/ContractsTest.php
@@ -204,7 +204,7 @@ class ContractsTest extends WP_UnitTestCase {
 	 * A stats summary always carries the full documented key set.
 	 */
 	public function test_stats_summary_shape() {
-		$expected = array( 'minutes', 'hours', 'runtime', 'entries', 'episodes', 'films', 'shows', 'since' );
+		$expected = array( 'minutes', 'hours', 'runtime', 'entries', 'episodes', 'films', 'shows', 'since', 'since_iso' );
 		$actual   = array_keys( Traktivity_Stats::get_summary() );
 
 		sort( $expected );
@@ -223,7 +223,7 @@ class ContractsTest extends WP_UnitTestCase {
 			$this->assertIsInt( $summary[ $key ], "Stats summary '{$key}' should be an integer." );
 		}
 
-		foreach ( array( 'runtime', 'since' ) as $key ) {
+		foreach ( array( 'runtime', 'since', 'since_iso' ) as $key ) {
 			$this->assertIsString( $summary[ $key ], "Stats summary '{$key}' should be a string." );
 		}
 	}

--- a/tests/php/StatsSummaryTest.php
+++ b/tests/php/StatsSummaryTest.php
@@ -1,0 +1,233 @@
+<?php
+/**
+ * Tests for the stats summary and its cache.
+ *
+ * @package Traktivity
+ */
+
+/**
+ * Headline figures for everything logged.
+ */
+class StatsSummaryTest extends WP_UnitTestCase {
+
+	/**
+	 * Start each test from a cold cache and an unguarded flush.
+	 */
+	public function set_up() {
+		parent::set_up();
+		Traktivity_Stats::reset_flush_guard();
+		Traktivity_Stats::flush( true );
+	}
+
+	/**
+	 * Create a published event.
+	 *
+	 * @param string $id_key  Either trakt_show_id or trakt_movie_id.
+	 * @param int    $runtime Minutes.
+	 * @param string $date    Post date.
+	 *
+	 * @return int Post ID.
+	 */
+	private function make_event( $id_key, $runtime = 60, $date = '2026-03-04 20:00:00' ) {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'traktivity_event',
+				'post_status' => 'publish',
+				'post_date'   => $date,
+			)
+		);
+
+		update_post_meta( $post_id, $id_key, 1 );
+		update_post_meta( $post_id, 'trakt_runtime', $runtime );
+
+		return $post_id;
+	}
+
+	/**
+	 * A site with nothing logged reports zeroes rather than failing.
+	 *
+	 * Blocks use this to tell "nothing synced yet" from "nothing to show", so
+	 * it needs to be a clean empty rather than an error.
+	 */
+	public function test_empty_site_reports_zeroes() {
+		$this->assertSame( Traktivity_Stats::empty_summary(), Traktivity_Stats::get_summary() );
+	}
+
+	/**
+	 * Episodes, films and totals are counted separately.
+	 */
+	public function test_counts() {
+		$this->make_event( 'trakt_show_id', 60 );
+		$this->make_event( 'trakt_show_id', 45 );
+		$this->make_event( 'trakt_movie_id', 120 );
+
+		Traktivity_Stats::flush( true );
+		$summary = Traktivity_Stats::get_summary();
+
+		$this->assertSame( 3, $summary['entries'] );
+		$this->assertSame( 2, $summary['episodes'] );
+		$this->assertSame( 1, $summary['films'] );
+		$this->assertSame( 225, $summary['minutes'] );
+		$this->assertSame( 3, $summary['hours'] );
+		$this->assertNotSame( '', $summary['runtime'] );
+	}
+
+	/**
+	 * Counts do not depend on the language the site runs in.
+	 *
+	 * The sync names trakt_type terms with a translated string, so counting
+	 * through that taxonomy would report zero films on a French site. These
+	 * count by ID meta instead, which matches how traktivity_get_event()
+	 * decides an event's type.
+	 */
+	public function test_counts_survive_translated_type_terms() {
+		$movie = $this->make_event( 'trakt_movie_id', 100 );
+		wp_set_object_terms( $movie, array( 'Filme' ), 'trakt_type' );
+
+		$episode = $this->make_event( 'trakt_show_id', 30 );
+		wp_set_object_terms( $episode, array( 'Serie TV' ), 'trakt_type' );
+
+		Traktivity_Stats::flush( true );
+		$summary = Traktivity_Stats::get_summary();
+
+		$this->assertSame( 1, $summary['films'] );
+		$this->assertSame( 1, $summary['episodes'] );
+	}
+
+	/**
+	 * Distinct shows are counted, and empty ones left out.
+	 */
+	public function test_show_count() {
+		$post_id = $this->make_event( 'trakt_show_id' );
+		wp_set_object_terms( $post_id, array( 'Some Show' ), 'trakt_show' );
+
+		self::factory()->term->create(
+			array(
+				'taxonomy' => 'trakt_show',
+				'name'     => 'Never Watched',
+			)
+		);
+
+		Traktivity_Stats::flush( true );
+
+		$this->assertSame( 1, Traktivity_Stats::get_summary()['shows'] );
+	}
+
+	/**
+	 * The oldest event sets the "logging since" date, in both formats.
+	 */
+	public function test_since_uses_the_oldest_event() {
+		$this->make_event( 'trakt_show_id', 60, '2022-08-15 10:00:00' );
+		$this->make_event( 'trakt_show_id', 60, '2026-03-04 20:00:00' );
+
+		Traktivity_Stats::flush( true );
+		$summary = Traktivity_Stats::get_summary();
+
+		$this->assertStringContainsString( '2022', $summary['since'] );
+		$this->assertStringStartsWith( '2022-08-15', $summary['since_iso'] );
+	}
+
+	/**
+	 * The summary is cached rather than recomputed per request.
+	 */
+	public function test_summary_is_cached() {
+		$this->make_event( 'trakt_show_id' );
+		Traktivity_Stats::flush( true );
+
+		$first = Traktivity_Stats::get_summary();
+
+		$this->assertIsArray( get_transient( 'traktivity_stats_summary' ) );
+
+		// A second event, with no flush, must not show up while the cache stands.
+		$this->make_event( 'trakt_show_id' );
+
+		$this->assertSame( $first['entries'], Traktivity_Stats::get_summary()['entries'] );
+	}
+
+	/**
+	 * Deleting an event no longer leaves a stale total.
+	 *
+	 * The running total used to be incremented on insert and never touched on
+	 * delete, with no hook to invalidate it, so it drifted with no way back
+	 * short of deleting the option by hand.
+	 */
+	public function test_deleting_an_event_corrects_the_total() {
+		$keep   = $this->make_event( 'trakt_show_id', 60 );
+		$remove = $this->make_event( 'trakt_show_id', 90 );
+
+		Traktivity_Stats::flush( true );
+		$this->assertSame( 150, Traktivity_Stats::get_summary()['minutes'] );
+
+		Traktivity_Stats::reset_flush_guard();
+		wp_delete_post( $remove, true );
+
+		$this->assertSame( 60, Traktivity_Stats::get_summary()['minutes'] );
+		$this->assertSame( 1, Traktivity_Stats::get_summary()['entries'] );
+		$this->assertNotSame( 0, $keep );
+	}
+
+	/**
+	 * Saving an event drops the cache too.
+	 */
+	public function test_saving_an_event_drops_the_cache() {
+		Traktivity_Stats::flush( true );
+		Traktivity_Stats::get_summary();
+
+		Traktivity_Stats::reset_flush_guard();
+		$this->make_event( 'trakt_show_id' );
+
+		$this->assertFalse( get_transient( 'traktivity_stats_summary' ) );
+	}
+
+	/**
+	 * A post of another type leaves the cache alone.
+	 */
+	public function test_other_post_types_leave_the_cache_alone() {
+		$this->make_event( 'trakt_show_id' );
+		Traktivity_Stats::flush( true );
+		Traktivity_Stats::get_summary();
+
+		Traktivity_Stats::reset_flush_guard();
+		self::factory()->post->create( array( 'post_title' => 'A blog post' ) );
+
+		$this->assertIsArray( get_transient( 'traktivity_stats_summary' ) );
+	}
+
+	/**
+	 * A sync flushes once, not once per event.
+	 *
+	 * Hundreds of events land in a single request, and flushing on each would
+	 * force the running total to be recounted every time.
+	 */
+	public function test_flush_runs_once_per_request() {
+		Traktivity_Stats::flush( true );
+		Traktivity_Stats::get_summary();
+		Traktivity_Stats::reset_flush_guard();
+
+		$this->make_event( 'trakt_show_id' );
+		$this->assertFalse( get_transient( 'traktivity_stats_summary' ) );
+
+		// Warm it again; the next save in the same request must not clear it.
+		Traktivity_Stats::get_summary();
+		$this->make_event( 'trakt_show_id' );
+
+		$this->assertIsArray( get_transient( 'traktivity_stats_summary' ) );
+	}
+
+	/**
+	 * The summary is filterable.
+	 */
+	public function test_summary_is_filterable() {
+		add_filter(
+			'traktivity_stats_summary',
+			static function ( $summary ) {
+				$summary['extra'] = 'added';
+				return $summary;
+			}
+		);
+
+		Traktivity_Stats::flush( true );
+
+		$this->assertSame( 'added', Traktivity_Stats::get_summary()['extra'] );
+	}
+}


### PR DESCRIPTION
Fixes #688

## What it does

`Traktivity_Stats::get_summary()` returns the headline figures for a site:

| Key | |
|---|---|
| `minutes` / `hours` / `runtime` | Total time watched, raw and formatted |
| `entries` | Published events |
| `episodes` / `films` | Split by type |
| `shows` | Distinct shows with something logged |
| `since` / `since_iso` | Date of the oldest event |

Cached for half a day, since none of it changes between syncs. `Traktivity_Stats::flush()`
drops it, hooked to `save_post` and `deleted_post`.

## Rationale

`Traktivity_Stats` previously knew how to format minutes and how many minutes had
been watched. Everything else had to be counted by hand.

**The running total could drift.** It was incremented when the sync inserted an
event (`core.traktivity.php:634`) and never touched again, and there was no hook
to invalidate it. Delete an event and the total stayed too high, with no way back
short of deleting the option by hand. `flush()` clears it and lets the next read
recount, which is one indexed query. Recount rather than decrement, per the
decision on #683: a counter that's only ever nudged drifts as soon as one path is
missed, and this is that bug.

**Flushing is guarded to once per request.** A sync inserts hundreds of events in
a single request, each firing `save_post`. Without the guard every one of them
would drop the total and force a recount, which would be considerably worse than
the bug being fixed.

**Counts come from the ID meta, not `trakt_type`.** That term is named with a
translated string, so counting through it reports zero films on any site not
running in English. It would also disagree with the type `traktivity_get_event()`
reports for the same event.

## One thing worth a look

`entries` is counted with a `WP_Query` rather than `wp_count_posts()`. That
function reads a cache that isn't reliably dropped when a post is deleted, which
I hit while writing the tests:

```
before: publish=2
after:  publish=2      <- after wp_delete_post( $id, true )
query found: 1
```

The figures are cached here anyway, so there's nothing to gain from reading a
stale cache faster.

## Also in here

The dashboard reads its total from the summary now rather than reaching into the
`traktivity_stats` option, so it picks up the same invalidation. No visible
change; it was already showing the formatted total.

`since_iso` is a new key on the documented shape, added so a block can reformat
or sort a date it would otherwise only get pre-formatted. `ContractsTest` is
updated in the same PR, per AGENTS.md.

## Usage

```php
$stats = Traktivity_Stats::get_summary();

printf(
	/* translators: 1: hours watched. 2: number of shows. */
	esc_html__( '%1$s hours across %2$s shows', 'traktivity' ),
	esc_html( number_format_i18n( $stats['hours'] ) ),
	esc_html( number_format_i18n( $stats['shows'] ) )
);
```

A site with nothing synced reports zeroes throughout, which is how a block tells
"nothing logged yet" from "nothing to show". `traktivity_stats_summary` filters
the result.

## Testing

`composer run lint && composer run analyse` clean. PHPUnit 136 passing, 294
assertions.

New coverage: an empty site, the counts, counts under translated type terms, the
show count ignoring empty terms, both `since` formats, the cache being used,
deleting an event correcting the total, saving dropping the cache, other post
types leaving it alone, the once-per-request guard, and the filter.
