### PR TITLE
Set up block registration, so adding a block is adding a directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,8 @@ Plugin PHP sits at the root, named `<area>.traktivity.php`:
 | `templates.traktivity.php` | Block templates and template parts |
 | `admin.traktivity.php` | Dashboard page, admin only |
 | `widgets/` | The legacy classic widget |
-| `src/` | Dashboard React app, and block sources |
+| `src/` | Dashboard React app, and block sources under `src/blocks/` |
+| `assets/` | Static CSS that is not built, such as the shared block styles |
 | `tests/` | `php/`, `js/`, `e2e/`, `package/` |
 
 Those names look unusual because they are baked into the wordpress.org SVN
@@ -41,6 +42,15 @@ that reason. Follow the pattern rather than fixing it.
 milestone needs is already required, including the ones still empty. The same
 goes for the `files` allowlist in `package.json`. Both were wired up front
 precisely so parallel branches don't collide on them.
+
+## Blocks
+
+One directory per block under `src/blocks/`, built to `build/blocks/<name>/`.
+`Traktivity_Blocks` registers whatever the build produced, so adding a block is
+adding a directory. `src/blocks/README.md` has the details, including the two
+build behaviours worth knowing: the stylesheet is emitted as `style-index.css`
+rather than `style.css`, and `block.json` should list the `traktivity-shared`
+handle before its own stylesheet.
 
 ## Conventions
 

--- a/assets/blocks-shared.css
+++ b/assets/blocks-shared.css
@@ -1,0 +1,59 @@
+/**
+ * Presentation shared by more than one Traktivity block.
+ *
+ * The media frame and the missing-artwork placeholder are used by the event
+ * card, the latest watch, the top shows grid and the show header, so they live
+ * here rather than being repeated in four block stylesheets.
+ *
+ * Everything here leans on theme.json values, so a theme restyles these by
+ * changing its own presets rather than by out-specifying this file. There are
+ * deliberately no colours beyond the placeholder's, which needs to be visible
+ * against any background.
+ */
+
+.traktivity-frame {
+	overflow: hidden;
+	position: relative;
+	width: 100%;
+}
+
+.traktivity-frame img {
+	display: block;
+	height: 100%;
+	object-fit: cover;
+	width: 100%;
+}
+
+.traktivity-frame--landscape {
+	aspect-ratio: 16 / 9;
+}
+
+.traktivity-frame--poster {
+	aspect-ratio: 2 / 3;
+}
+
+/*
+ * TMDb does not have artwork for everything, so a meaningful share of events
+ * and shows will never get an image. This is a normal state rather than an
+ * error one, and it should read as a deliberate blank rather than a failure.
+ */
+.traktivity-frame--empty {
+	align-items: center;
+	background: currentcolor;
+	display: flex;
+	justify-content: center;
+	opacity: 0.08;
+}
+
+.traktivity-frame__label {
+	font-size: var(--wp--preset--font-size--small, 0.8125rem);
+	letter-spacing: 0.08em;
+	padding: 0.5em;
+	text-align: center;
+	text-transform: uppercase;
+}
+
+.traktivity-sep {
+	opacity: 0.5;
+	padding: 0 0.35em;
+}

--- a/blocks.traktivity.php
+++ b/blocks.traktivity.php
@@ -2,13 +2,10 @@
 /**
  * Block registration.
  *
- * Placeholder. The registration class, the traktivity block category and the
- * shared `traktivity-shared` stylesheet all land here in issue #689, and the
- * seven blocks in #690 to #696.
- *
- * The file exists already, and is wired into Traktivity::load_plugin(), so
- * that work does not have to touch traktivity.php and conflict with the rest
- * of the 3.1.0 milestone.
+ * Blocks live in src/blocks/<name>/ and are built into build/blocks/<name>/ by
+ * wp-scripts, which picks up each block.json on its own. This file finds what
+ * the build produced and registers it, so adding a block means adding a
+ * directory rather than editing a list here.
  *
  * @package Traktivity
  */
@@ -16,3 +13,168 @@
 declare( strict_types = 1 );
 
 defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
+
+/**
+ * Register the plugin's blocks, their category and their shared styles.
+ *
+ * @since 3.1.0
+ */
+class Traktivity_Blocks {
+
+	/**
+	 * Handle for the stylesheet shared by several blocks.
+	 *
+	 * @var string
+	 */
+	const SHARED_STYLE_HANDLE = 'traktivity-shared';
+
+	/**
+	 * Slug for the plugin's block category.
+	 *
+	 * @var string
+	 */
+	const CATEGORY = 'traktivity';
+
+	/**
+	 * Hook everything up.
+	 *
+	 * @since 3.1.0
+	 */
+	public static function init(): void {
+		add_filter( 'block_categories_all', array( __CLASS__, 'register_category' ) );
+		add_action( 'init', array( __CLASS__, 'register_shared_style' ), 5 );
+		add_action( 'init', array( __CLASS__, 'register_blocks_on_init' ) );
+	}
+
+	/**
+	 * Add a Traktivity category, so the blocks sit together in the inserter.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param array $categories Registered block categories.
+	 *
+	 * @return array Categories, with ours appended.
+	 */
+	public static function register_category( $categories ) {
+		if ( ! is_array( $categories ) ) {
+			return $categories;
+		}
+
+		foreach ( $categories as $category ) {
+			if ( isset( $category['slug'] ) && self::CATEGORY === $category['slug'] ) {
+				return $categories;
+			}
+		}
+
+		$categories[] = array(
+			'slug'  => self::CATEGORY,
+			'title' => __( 'Traktivity', 'traktivity' ),
+			'icon'  => null,
+		);
+
+		return $categories;
+	}
+
+	/**
+	 * Register the stylesheet several blocks share.
+	 *
+	 * Registered at priority 5, ahead of the blocks themselves, because a
+	 * block.json naming this handle in its `style` array needs it to exist by
+	 * the time the block is registered.
+	 *
+	 * The frame and the missing-artwork placeholder are used by four blocks.
+	 * Keeping them in one handle rather than repeating them in four block
+	 * stylesheets means a page using two blocks downloads them once.
+	 *
+	 * @since 3.1.0
+	 */
+	public static function register_shared_style(): void {
+		$relative = 'assets/blocks-shared.css';
+		$path     = TRAKTIVITY__PLUGIN_DIR . $relative;
+
+		wp_register_style(
+			self::SHARED_STYLE_HANDLE,
+			plugins_url( $relative, TRAKTIVITY__PLUGIN_DIR . 'traktivity.php' ),
+			array(),
+			file_exists( $path ) ? (string) filemtime( $path ) : TRAKTIVITY__VERSION
+		);
+	}
+
+	/**
+	 * Directories under build/blocks/ that hold a block.json.
+	 *
+	 * Reading the built directory rather than the source one, so the generated
+	 * asset files sit alongside the metadata that points at them.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param string $base Directory to scan. Defaults to the plugin's build output.
+	 *
+	 * @return string[] Absolute paths, sorted so registration order is stable.
+	 */
+	public static function block_directories( string $base = '' ): array {
+		if ( '' === $base ) {
+			$base = TRAKTIVITY__PLUGIN_DIR . 'build/blocks';
+		}
+
+		if ( ! is_dir( $base ) ) {
+			return array();
+		}
+
+		$directories = glob( untrailingslashit( $base ) . '/*', GLOB_ONLYDIR );
+
+		if ( false === $directories ) {
+			return array();
+		}
+
+		$blocks = array_values(
+			array_filter(
+				$directories,
+				static function ( $directory ) {
+					return file_exists( $directory . '/block.json' );
+				}
+			)
+		);
+
+		sort( $blocks );
+
+		return $blocks;
+	}
+
+	/**
+	 * Register the blocks on init.
+	 *
+	 * A thin void wrapper, because register_blocks() reports what it
+	 * registered and an action callback must not return anything.
+	 *
+	 * @since 3.1.0
+	 */
+	public static function register_blocks_on_init(): void {
+		self::register_blocks();
+	}
+
+	/**
+	 * Register every block the build produced.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param string $base Directory to scan. Defaults to the plugin's build output.
+	 *
+	 * @return string[] Names of the blocks that registered.
+	 */
+	public static function register_blocks( string $base = '' ): array {
+		$registered = array();
+
+		foreach ( self::block_directories( $base ) as $directory ) {
+			$type = register_block_type( $directory );
+
+			if ( $type instanceof WP_Block_Type ) {
+				$registered[] = $type->name;
+			}
+		}
+
+		return $registered;
+	}
+}
+
+Traktivity_Blocks::init();

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Log your activity on Trakt.tv",
   "main": "traktivity.php",
   "files": [
+    "assets",
     "build",
     "widgets",
     "admin.traktivity.php",

--- a/src/blocks/README.md
+++ b/src/blocks/README.md
@@ -1,0 +1,32 @@
+# Blocks
+
+One directory per block. `wp-scripts` finds each `block.json` on its own, so
+adding a block means adding a directory here, not editing a build config or a
+registration list.
+
+```
+src/blocks/event-card/
+	block.json
+	index.js        <- registerBlockType, and `import './style.scss'`
+	render.php      <- server render
+	style.scss      <- front-end styles for this block only
+```
+
+That builds to `build/blocks/event-card/`, and `Traktivity_Blocks` registers
+whatever it finds there.
+
+Two things the build decides for you, both verified rather than assumed:
+
+- The stylesheet comes out as `style-index.css`, because webpack names it after
+  the entry that imported it. So `block.json` says
+  `"style": [ "traktivity-shared", "file:./style-index.css" ]`, not `style.css`.
+- `render.php` is copied across as-is, so `"render": "file:./render.php"` works
+  from the built directory.
+
+`traktivity-shared` carries the media frame and the missing-artwork placeholder,
+which four blocks reuse. List it first, then the block's own stylesheet; a page
+using two blocks then downloads the shared rules once. Put anything specific to
+one block in that block's `style.scss`.
+
+Blocks go in the `traktivity` category, and take colour, spacing and typography
+through `supports` rather than hard-coding any of it.

--- a/tests/package/verify-package.mjs
+++ b/tests/package/verify-package.mjs
@@ -52,6 +52,7 @@ const allowed = [
 	/^[^/]+\.php$/, // Plugin PHP at the root.
 	/^widgets\/[^/]+\.php$/,
 	/^build\//,
+	/^assets\/[^/]+\.css$/,
 	/^readme\.txt$/,
 	/^LICENSE\.md$/,
 ];
@@ -92,6 +93,8 @@ for ( const required of [
 	'build/index.js',
 	'build/index.asset.php',
 	'build/style-index.css',
+	// Shared by several blocks; a block.json naming the handle needs it present.
+	'assets/blocks-shared.css',
 ] ) {
 	check( has( required ), `ships ${ required }` );
 }

--- a/tests/php/BlockRegistrationTest.php
+++ b/tests/php/BlockRegistrationTest.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Tests for block registration.
+ *
+ * @package Traktivity
+ */
+
+/**
+ * Finding and registering whatever the build produced.
+ */
+class BlockRegistrationTest extends WP_UnitTestCase {
+
+	/**
+	 * Fixture directory standing in for build/blocks.
+	 *
+	 * @var string
+	 */
+	private $fixtures;
+
+	/**
+	 * Point the registrar at the fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->fixtures = __DIR__ . '/fixtures/blocks';
+	}
+
+	/**
+	 * Registered blocks are unregistered again, so tests stay independent.
+	 */
+	public function tear_down() {
+		$registry = WP_Block_Type_Registry::get_instance();
+
+		if ( $registry->is_registered( 'traktivity/example' ) ) {
+			unregister_block_type( 'traktivity/example' );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Only directories holding a block.json are treated as blocks.
+	 */
+	public function test_only_block_directories_are_found() {
+		$found = Traktivity_Blocks::block_directories( $this->fixtures );
+
+		$this->assertCount( 1, $found );
+		$this->assertStringEndsWith( '/example', $found[0] );
+	}
+
+	/**
+	 * A missing build directory is not an error.
+	 *
+	 * The plugin has to survive being installed without its build output, so
+	 * this returns nothing rather than warning.
+	 */
+	public function test_missing_directory_returns_nothing() {
+		$this->assertSame( array(), Traktivity_Blocks::block_directories( __DIR__ . '/nope' ) );
+	}
+
+	/**
+	 * A built block registers.
+	 */
+	public function test_blocks_register() {
+		$registered = Traktivity_Blocks::register_blocks( $this->fixtures );
+
+		$this->assertSame( array( 'traktivity/example' ), $registered );
+		$this->assertTrue( WP_Block_Type_Registry::get_instance()->is_registered( 'traktivity/example' ) );
+	}
+
+	/**
+	 * A block declaring the shared handle keeps it.
+	 *
+	 * Four blocks reuse the frame and placeholder rules, so each block.json
+	 * lists the shared handle alongside its own stylesheet. If registration
+	 * dropped it, every one of those blocks would render unstyled.
+	 */
+	public function test_shared_style_handle_survives_registration() {
+		Traktivity_Blocks::register_blocks( $this->fixtures );
+
+		$type = WP_Block_Type_Registry::get_instance()->get_registered( 'traktivity/example' );
+
+		$this->assertContains( Traktivity_Blocks::SHARED_STYLE_HANDLE, (array) $type->style_handles );
+	}
+
+	/**
+	 * The shared stylesheet is registered before any block needs it.
+	 */
+	public function test_shared_style_is_registered() {
+		Traktivity_Blocks::register_shared_style();
+
+		$this->assertTrue( wp_style_is( Traktivity_Blocks::SHARED_STYLE_HANDLE, 'registered' ) );
+	}
+
+	/**
+	 * The shared stylesheet actually ships.
+	 */
+	public function test_shared_stylesheet_exists() {
+		$this->assertFileExists( TRAKTIVITY__PLUGIN_DIR . 'assets/blocks-shared.css' );
+	}
+
+	/**
+	 * The block category is added for the inserter.
+	 */
+	public function test_category_is_added() {
+		$categories = Traktivity_Blocks::register_category( array( array( 'slug' => 'text' ) ) );
+		$slugs      = wp_list_pluck( $categories, 'slug' );
+
+		$this->assertContains( Traktivity_Blocks::CATEGORY, $slugs );
+	}
+
+	/**
+	 * The category is not added twice.
+	 */
+	public function test_category_is_not_duplicated() {
+		$once  = Traktivity_Blocks::register_category( array( array( 'slug' => 'text' ) ) );
+		$twice = Traktivity_Blocks::register_category( $once );
+
+		$this->assertSame( $once, $twice );
+	}
+
+	/**
+	 * Registration is wired to init.
+	 */
+	public function test_registration_is_hooked() {
+		$this->assertNotFalse( has_action( 'init', array( 'Traktivity_Blocks', 'register_blocks_on_init' ) ) );
+		$this->assertNotFalse( has_action( 'init', array( 'Traktivity_Blocks', 'register_shared_style' ) ) );
+		$this->assertNotFalse( has_filter( 'block_categories_all', array( 'Traktivity_Blocks', 'register_category' ) ) );
+	}
+}

--- a/tests/php/fixtures/blocks/example/block.json
+++ b/tests/php/fixtures/blocks/example/block.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "traktivity/example",
+	"title": "Example",
+	"category": "traktivity",
+	"description": "Fixture used to prove the registrar finds and registers a built block.",
+	"textdomain": "traktivity",
+	"supports": { "html": false },
+	"style": [ "traktivity-shared" ]
+}

--- a/tests/php/fixtures/blocks/not-a-block/readme.txt
+++ b/tests/php/fixtures/blocks/not-a-block/readme.txt
@@ -1,0 +1,1 @@
+not a block


### PR DESCRIPTION
Fixes #689

## What it does

Sets up everything the seven block issues sit on, so each of them is a new
directory rather than a new set of decisions.

- `Traktivity_Blocks` scans `build/blocks` for directories holding a
  `block.json` and registers what it finds. Adding a block never edits a list.
- A `traktivity` block category, so the blocks group together in the inserter
  instead of scattering through Widgets.
- `assets/blocks-shared.css`, registered as `traktivity-shared`, carrying the
  media frame and the missing-artwork placeholder.
- `src/blocks/README.md` and an AGENTS.md section documenting the conventions.

## Two build behaviours, checked rather than assumed

Getting either of these wrong breaks a block quietly, so I built a throwaway
block and looked at the output instead of trusting the docs.

**Blocks build to `build/blocks/<name>/`,** with `block.json` and `render.php`
copied across as-is:

```
build/blocks/__probe/block.json
build/blocks/__probe/index.asset.php
build/blocks/__probe/index.js
build/blocks/__probe/render.php
```

**A stylesheet imported from a block's `index.js` comes out as `style-index.css`,**
not `style.css` — webpack names it after the entry, not the source file. So
`block.json` has to say:

```json
"style": [ "traktivity-shared", "file:./style-index.css" ]
```

The probe is removed; it existed to answer those two questions.

## Rationale

**The shared stylesheet ships as plain CSS in `assets/` rather than going through
the build.** Nothing about forty lines of layout needs compiling, and a webpack
entry for a standalone stylesheet means a custom `webpack.config.js` that then
has to be maintained. The release archive allowlist is widened to match, and the
file is *required* rather than merely permitted, so dropping it fails the package
check instead of quietly shipping four unstyled blocks.

Four of the seven blocks reuse the frame and the placeholder, so keeping them in
one handle means a page using two blocks downloads those rules once. This is the
"shared base plus per-block" split decided on #683.

`register_shared_style()` runs on `init` at priority 5, ahead of the blocks, so a
`block.json` naming the handle finds it registered.

**The registrar takes the directory to scan as an argument.** Tests then run
against a fixture rather than against whatever the last build happened to leave
behind, which also means the suite doesn't need a build to pass.

## Also in here

`register_blocks()` returns the names it registered, which is useful in tests but
not allowed for an action callback, so `init` gets a void wrapper. PHPStan caught
that one.

## Testing

`composer run lint && composer run analyse` clean. PHPUnit 145 passing, 307
assertions. `npm run build`, `test:package`, `lint:js`, `lint:css` and
`test:unit` all pass.

New coverage: only directories with a `block.json` are found, a missing build
directory returns nothing rather than warning, a block registers, the shared
handle survives registration, the stylesheet is registered and present on disk,
the category is added and not duplicated, and everything is hooked.

The webpack side is proven by the probe above; #690 will be the first block to
exercise it for real.
