### PR TITLE
Add an Event Card block, the first thing to render a watch event

### DIFF
--- a/blocks.traktivity.php
+++ b/blocks.traktivity.php
@@ -175,6 +175,71 @@ class Traktivity_Blocks {
 
 		return $registered;
 	}
+
+	/**
+	 * Render the blank frame used wherever artwork is missing.
+	 *
+	 * TMDb does not have an image for everything, so a meaningful share of events
+	 * and shows will never get one. This is a normal state rather than an error
+	 * state, and it should read as a deliberate blank rather than a broken image.
+	 *
+	 * The title is printed next to this frame by every caller, so repeating it
+	 * inside only overflows the smaller cards. The frame carries the title as its
+	 * accessible name and shows a short label instead.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param string $title  Title of the show, film or episode.
+	 * @param string $aspect Either 'landscape' or 'poster'.
+	 *
+	 * @return string HTML.
+	 */
+	public static function placeholder( string $title, string $aspect = 'landscape' ): string {
+		return sprintf(
+			'<div class="traktivity-frame traktivity-frame--%1$s traktivity-frame--empty" role="img" aria-label="%2$s"><span class="traktivity-frame__label">%3$s</span></div>',
+			esc_attr( 'poster' === $aspect ? 'poster' : 'landscape' ),
+			/* translators: %s: title of the show, film or episode. */
+			esc_attr( sprintf( __( '%s, no artwork available', 'traktivity' ), $title ) ),
+			esc_html__( 'No artwork', 'traktivity' )
+		);
+	}
+
+	/**
+	 * Render an image inside a fixed-ratio frame, falling back to the placeholder.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param int    $image_id Attachment ID.
+	 * @param string $title    Title, used as alt text and in the placeholder label.
+	 * @param string $aspect   Either 'landscape' or 'poster'.
+	 *
+	 * @return string HTML.
+	 */
+	public static function frame( int $image_id, string $title, string $aspect = 'landscape' ): string {
+		if ( $image_id < 1 ) {
+			return self::placeholder( $title, $aspect );
+		}
+
+		$image = wp_get_attachment_image(
+			$image_id,
+			'poster' === $aspect ? 'medium_large' : 'large',
+			false,
+			array(
+				'alt'     => $title,
+				'loading' => 'lazy',
+			)
+		);
+
+		if ( '' === $image ) {
+			return self::placeholder( $title, $aspect );
+		}
+
+		return sprintf(
+			'<div class="traktivity-frame traktivity-frame--%1$s">%2$s</div>',
+			esc_attr( 'poster' === $aspect ? 'poster' : 'landscape' ),
+			$image
+		);
+	}
 }
 
 Traktivity_Blocks::init();

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,13 +13,16 @@
         "@testing-library/react": "^16.3.3",
         "@testing-library/user-event": "^14.6.6",
         "@wordpress/api-fetch": "^7.54.0",
+        "@wordpress/block-editor": "^17.0.0",
+        "@wordpress/blocks": "^15.27.0",
         "@wordpress/components": "^40.0.0",
         "@wordpress/e2e-test-utils-playwright": "^1.54.0",
         "@wordpress/element": "^8.6.0",
         "@wordpress/env": "^11.14.0",
         "@wordpress/i18n": "^6.27.0",
         "@wordpress/jest-console": "^9.2.0",
-        "@wordpress/scripts": "^34.2.0"
+        "@wordpress/scripts": "^34.2.0",
+        "@wordpress/server-side-render": "^6.30.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -30,9 +33,9 @@
       "license": "MIT"
     },
     "node_modules/@ariakit/components": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@ariakit/components/-/components-0.1.11.tgz",
-      "integrity": "sha512-hFmfWKkK8jpATf39kNZSMDlG3o+tftfQwyooRhbPl/YCpFur+IGz5ZPA+PGIIfFjfdkAURLNDJPSeWtXO3xssQ==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@ariakit/components/-/components-0.1.12.tgz",
+      "integrity": "sha512-50Rg4Fp7W49fEVqa16eX2eYoIDrMGr+NbrQeTy0ujVZ/d12qwNZsdyA+wnbDfaZjoTy717Ohu0YYMAW+8tUusA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -41,13 +44,13 @@
       }
     },
     "node_modules/@ariakit/react": {
-      "version": "0.4.38",
-      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.38.tgz",
-      "integrity": "sha512-VubItCXqly9GNFxulOYDkFP94jh1M5iHeuo0BDTTiN1ndrGNeZCvsRUWd06BC9yjg+/LKEAnFLeolE1pG1IQBg==",
+      "version": "0.4.39",
+      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.39.tgz",
+      "integrity": "sha512-Urj6knR0+xJzs/xpccl3AKB0OwDlEZvvUI3BFcb7QJge96quy8cub5QLwsE1Suiu1jUBvj4GIbja3jGhuU301w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ariakit/react-components": "0.5.0"
+        "@ariakit/react-components": "0.6.0"
       },
       "funding": {
         "type": "opencollective",
@@ -59,13 +62,13 @@
       }
     },
     "node_modules/@ariakit/react-components": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@ariakit/react-components/-/react-components-0.5.0.tgz",
-      "integrity": "sha512-NEpptkB3sJZrwTIIzFydyGjLGVLpfDt0X3naLh9x2Z0WyIkJuz6ZbzyWAxMrc9m4oNJgnex4cy5MZYndrJTtKQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@ariakit/react-components/-/react-components-0.6.0.tgz",
+      "integrity": "sha512-T+u+8UzJEGbEg9f4yb76MFjaWMY9NYd47Bk8MOMStDuMh+vyn3GKj1m6++7gXUziQ+wD2f+uQkB3n+ay1seKbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ariakit/components": "0.1.11",
+        "@ariakit/components": "0.1.12",
         "@ariakit/react-store": "0.1.10",
         "@ariakit/react-utils": "0.2.5",
         "@ariakit/store": "0.1.9",
@@ -2111,14 +2114,14 @@
       }
     },
     "node_modules/@base-ui/react": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.7.0.tgz",
-      "integrity": "sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.8.0.tgz",
+      "integrity": "sha512-P0/1sxo6SBVZOklKMIedvTWqw2s2IQzi9x5bIVsXu980cuSOD4NeuRSs+/L7LZQfDkZP/uRZyGPyfFl/B1oH+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@base-ui/utils": "0.3.2",
+        "@babel/runtime": "^7.29.7",
+        "@base-ui/utils": "0.4.0",
         "@floating-ui/react-dom": "^2.1.9",
         "@floating-ui/utils": "^0.2.12",
         "use-sync-external-store": "^1.6.0"
@@ -2150,13 +2153,13 @@
       }
     },
     "node_modules/@base-ui/utils": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.2.tgz",
-      "integrity": "sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.4.0.tgz",
+      "integrity": "sha512-bO9fz25kKtPf+aZVyfQrC0PDmJdmVni31W2hCS5/Owb+inwdIL3XU26pCPRPlt4LSxZrBgLwubXQXQlKaFEZzw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.29.2",
+        "@babel/runtime": "^7.29.7",
         "@floating-ui/utils": "^0.2.12",
         "reselect": "^5.2.0",
         "use-sync-external-store": "^1.6.0"
@@ -6736,6 +6739,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@preact/signals": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.3.4.tgz",
+      "integrity": "sha512-TPMkStdT0QpSc8FpB63aOwXoSiZyIrPsP9Uj347KopdS6olZdAYeeird/5FZv/M1Yc1ge5qstub2o8VDbvkT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@preact/signals-core": "^1.7.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact": "10.x"
+      }
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz",
+      "integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/@prisma/instrumentation": {
       "version": "6.11.1",
       "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-6.11.1.tgz",
@@ -6782,6 +6813,414 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.23.tgz",
+      "integrity": "sha512-Ksw4WeROkO4rC9k/onilX/Ao2Cr1ku1unMNH+XSCcP4jSXYu7HDsg9n4ojMjVb22XpYjAQ9qfrFlVbru1vXDUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+      "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-effect-event": "0.0.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
+      "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+      "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+      "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+      "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-spring/animated": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.5.tgz",
+      "integrity": "sha512-Tqrwz7pIlsSDITzxoLS3n/v/YCUHQdOIKtOJf4yL6kYVSDTSmVK1LI1Q3M/uu2Sx4X3pIWF3xLUhlsA6SPNTNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/core": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.7.5.tgz",
+      "integrity": "sha512-rmEqcxRcu7dWh7MnCcMXLvrf6/SDlSokLaLTxiPlAYi11nN3B5oiCUAblO72o+9z/87j2uzxa2Inm8UbLjXA+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~9.7.5",
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-spring/donate"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/rafz": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.7.5.tgz",
+      "integrity": "sha512-5ZenDQMC48wjUzPAm1EtwQ5Ot3bLIAwwqP2w2owG5KoNdNHpEJV263nGhCeKKmuA3vG2zLLOdu3or6kuDjA6Aw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/shared": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.7.5.tgz",
+      "integrity": "sha512-wdtoJrhUeeyD/PP/zo+np2s1Z820Ohr/BbuVYv+3dVLW7WctoiN7std8rISoYoHpUXtbkpesSKuPIw/6U1w1Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/rafz": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/types": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.5.tgz",
+      "integrity": "sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/web": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-9.7.5.tgz",
+      "integrity": "sha512-lmvqGwpe+CSttsWNZVr+Dg62adtKhauGwLyGE/RRyZ8AAMLgb9x3NDMA5RMElXo+IMyTkPp7nxTB8ZQlmhb6JQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~9.7.5",
+        "@react-spring/core": "~9.7.5",
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -7611,6 +8050,23 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/dom-mediacapture-transform": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-transform/-/dom-mediacapture-transform-0.1.12.tgz",
+      "integrity": "sha512-d7/QsLRwF864A5mgIM/YrfiglHoYn7zgCcAoJgW404r+2DwnNr7EBbLnCWpmOMgH8y0te73L1AV6H1bmauaWFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/dom-webcodecs": "*"
+      }
+    },
+    "node_modules/@types/dom-webcodecs": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.13.tgz",
+      "integrity": "sha512-O5hkiFIcjjszPIYyUSyvScyvrBoV3NOEEZx/pMlsu44TKzWNkLVBBxnxJz42in5n3QIolYOcBYFCPZZ0h8SkwQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -8895,6 +9351,17 @@
         "npm": ">=8.19.2"
       }
     },
+    "node_modules/@wordpress/autop": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.54.0.tgz",
+      "integrity": "sha512-SaxCrUJ6jhKZspq/HiMISD/cBTnloZxfFrckv6G26C1zpexKKWHZHUod/1n19j5C/IInpuHhzeS1eHxZgdg0zw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
     "node_modules/@wordpress/babel-preset-default": {
       "version": "8.54.0",
       "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.54.0.tgz",
@@ -8919,19 +9386,6 @@
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/babel-preset-default/node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/@wordpress/base-styles": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-13.0.0.tgz",
@@ -8943,6 +9397,189 @@
         "npm": ">=8.19.2"
       }
     },
+    "node_modules/@wordpress/blob": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.54.0.tgz",
+      "integrity": "sha512-/9s3JpYBNlK44v9V1fHT0dgPVxDVzcNss6cbGk/kNOtntoLJkBaRWLjCXm9WGWQ2kv2sm6PLDzlSiiOCF5sPHg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/block-editor": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-17.0.0.tgz",
+      "integrity": "sha512-RGWvjWLwIKMKEgLt6kZseC+oEO7oNnDFMzfZ56eGuQKZCKM88x5F7jaEly6YWqj8XtonXEz1ihfxL5JrPeSFNg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@react-spring/web": "^9.4.5",
+        "@wordpress/a11y": "^4.54.0",
+        "@wordpress/base-styles": "^13.0.0",
+        "@wordpress/blob": "^4.54.0",
+        "@wordpress/block-serialization-default-parser": "^5.54.0",
+        "@wordpress/blocks": "^15.27.0",
+        "@wordpress/commands": "^1.54.0",
+        "@wordpress/components": "^40.0.0",
+        "@wordpress/compose": "^8.7.0",
+        "@wordpress/data": "^10.54.0",
+        "@wordpress/dataviews": "^18.1.0",
+        "@wordpress/date": "^5.54.0",
+        "@wordpress/deprecated": "^4.54.0",
+        "@wordpress/dom": "^4.54.0",
+        "@wordpress/element": "^8.6.0",
+        "@wordpress/escape-html": "^3.54.0",
+        "@wordpress/global-styles-engine": "^1.21.0",
+        "@wordpress/hooks": "^4.54.0",
+        "@wordpress/html-entities": "^4.54.0",
+        "@wordpress/i18n": "^6.27.0",
+        "@wordpress/icons": "^15.5.0",
+        "@wordpress/image-cropper": "^1.18.0",
+        "@wordpress/interactivity": "^6.54.0",
+        "@wordpress/is-shallow-equal": "^5.54.0",
+        "@wordpress/kebab-case": "^1.1.0",
+        "@wordpress/keyboard-shortcuts": "^5.54.0",
+        "@wordpress/keycodes": "^4.54.0",
+        "@wordpress/notices": "^5.54.0",
+        "@wordpress/preferences": "^4.54.0",
+        "@wordpress/priority-queue": "^3.54.0",
+        "@wordpress/private-apis": "^1.54.0",
+        "@wordpress/rich-text": "^7.54.0",
+        "@wordpress/style-engine": "^2.54.0",
+        "@wordpress/token-list": "^3.54.0",
+        "@wordpress/ui": "^0.21.0",
+        "@wordpress/upload-media": "^0.39.0",
+        "@wordpress/url": "^4.54.0",
+        "@wordpress/warning": "^3.54.0",
+        "@wordpress/wordcount": "^4.54.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.9.3",
+        "deepmerge": "^4.3.1",
+        "diff": "^8.0.3",
+        "fast-deep-equal": "^3.1.3",
+        "parsel-js": "^1.1.2",
+        "postcss": "^8.4.38",
+        "postcss-prefix-selector": "^1.16.0",
+        "postcss-urlrebase": "^1.4.0",
+        "react-autosize-textarea": "^7.1.0",
+        "react-easy-crop": "^5.4.2",
+        "remove-accents": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/block-editor/node_modules/react-autosize-textarea": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-7.1.0.tgz",
+      "integrity": "sha512-BHpjCDkuOlllZn3nLazY2F8oYO1tS2jHnWhcjTWQdcKiiMU6gHLNt/fzmqMSyerR0eTdKtfSIqtSeTtghNwS+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "autosize": "^4.0.2",
+        "line-height": "^0.3.1",
+        "prop-types": "^15.5.6"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
+        "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@wordpress/block-serialization-default-parser": {
+      "version": "5.54.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.54.0.tgz",
+      "integrity": "sha512-7y2wtF7+QUlyFuhpIMI0JxI1EK6vbiYFKWvnPeqhaulg9b2xPG1IFjhZNKD+5oQgvOpRU2tKV/fisbagqxdqgA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/blocks": {
+      "version": "15.27.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.27.0.tgz",
+      "integrity": "sha512-HW8SJBMF2HhZn8/9XKxu37Rspm3Oqb5odGHnpcc29jZKbYRzH/7AhEUYAdjuUedVwXB2UvzaybDMFFOZ6lN4FA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/autop": "^4.54.0",
+        "@wordpress/blob": "^4.54.0",
+        "@wordpress/block-serialization-default-parser": "^5.54.0",
+        "@wordpress/data": "^10.54.0",
+        "@wordpress/deprecated": "^4.54.0",
+        "@wordpress/dom": "^4.54.0",
+        "@wordpress/element": "^8.6.0",
+        "@wordpress/hooks": "^4.54.0",
+        "@wordpress/html-entities": "^4.54.0",
+        "@wordpress/i18n": "^6.27.0",
+        "@wordpress/is-shallow-equal": "^5.54.0",
+        "@wordpress/keycodes": "^4.54.0",
+        "@wordpress/private-apis": "^1.54.0",
+        "@wordpress/rich-text": "^7.54.0",
+        "@wordpress/shortcode": "^4.54.0",
+        "@wordpress/warning": "^3.54.0",
+        "change-case": "^4.1.2",
+        "colord": "^2.9.3",
+        "fast-deep-equal": "^3.1.3",
+        "hpq": "^1.4.0",
+        "is-plain-object": "^5.1.0",
+        "marked": "^18.0.3",
+        "memize": "^2.1.1",
+        "react-is": "^18.3.0",
+        "remove-accents": "^0.5.0",
+        "simple-html-tokenizer": "^0.5.7",
+        "uuid": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/blocks/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@wordpress/blocks/node_modules/uuid": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.2.tgz",
+      "integrity": "sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
     "node_modules/@wordpress/browserslist-config": {
       "version": "6.54.0",
       "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.54.0.tgz",
@@ -8952,6 +9589,36 @@
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/commands": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.54.0.tgz",
+      "integrity": "sha512-TUo0n4011kzxkIGyHT9yz38c731rONyctmyynQO0Tro/uP8MhxNbWdzMOjzJXNwZTCqEME5b7WVTgT/bF7WCvw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/base-styles": "^13.0.0",
+        "@wordpress/components": "^40.0.0",
+        "@wordpress/data": "^10.54.0",
+        "@wordpress/element": "^8.6.0",
+        "@wordpress/i18n": "^6.27.0",
+        "@wordpress/icons": "^15.5.0",
+        "@wordpress/keyboard-shortcuts": "^5.54.0",
+        "@wordpress/keycodes": "^4.54.0",
+        "@wordpress/preferences": "^4.54.0",
+        "@wordpress/private-apis": "^1.54.0",
+        "@wordpress/warning": "^3.54.0",
+        "clsx": "^2.1.1",
+        "cmdk": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/@wordpress/components": {
@@ -9136,6 +9803,52 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/dataviews": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-18.1.0.tgz",
+      "integrity": "sha512-vV3wvSnqxjGqsUj9fnRmVVzXVCy/N+pRGYx+WyyXZUslbLX9xn1JfI2Z8uXFptKZJ5vGJ3BnLkfE4r2HdvG0Zg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.37",
+        "@date-fns/tz": "^1.5.0",
+        "@wordpress/a11y": "^4.54.0",
+        "@wordpress/base-styles": "^13.0.0",
+        "@wordpress/components": "^40.0.0",
+        "@wordpress/compose": "^8.7.0",
+        "@wordpress/data": "^10.54.0",
+        "@wordpress/date": "^5.54.0",
+        "@wordpress/deprecated": "^4.54.0",
+        "@wordpress/element": "^8.6.0",
+        "@wordpress/i18n": "^6.27.0",
+        "@wordpress/icons": "^15.5.0",
+        "@wordpress/kebab-case": "^1.1.0",
+        "@wordpress/keycodes": "^4.54.0",
+        "@wordpress/primitives": "^4.54.0",
+        "@wordpress/ui": "^0.21.0",
+        "@wordpress/warning": "^3.54.0",
+        "clsx": "^2.1.1",
+        "colord": "^2.9.3",
+        "date-fns": "^4.4.0",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "remove-accents": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/date": {
@@ -9350,6 +10063,52 @@
         }
       }
     },
+    "node_modules/@wordpress/eslint-plugin/node_modules/@wordpress/theme": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-2.0.0.tgz",
+      "integrity": "sha512-4yFei1ayJinMOVY6cTzKZV961p2Vjex9Nst1SReIFKv3ckb6ih5QN+qMpJQdpuukwabXrBTaoiA4ZB1akl2CfQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/compose": "^8.7.0",
+        "@wordpress/deprecated": "^4.54.0",
+        "@wordpress/element": "^8.6.0",
+        "@wordpress/private-apis": "^1.54.0",
+        "@wordpress/style-runtime": "^0.10.0",
+        "colorjs.io": "^0.7.1",
+        "memize": "^2.1.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.13.0",
+        "npm": ">=10.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "esbuild": ">=0.27.2 <1.0.0",
+        "postcss": "^8.0.0",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19",
+        "stylelint": "^16 || ^17",
+        "vite": "^7 || ^8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "stylelint": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@wordpress/eslint-plugin/node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -9375,6 +10134,29 @@
       "license": "ISC",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@wordpress/global-styles-engine": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/global-styles-engine/-/global-styles-engine-1.21.0.tgz",
+      "integrity": "sha512-90qh8jHOSqghRLKHmJxg32rNXU9AQ8pjVlH1wjmJywq3h0d4qABSRUSKm2nb5HLwF1zbIX7xTbdLMqqXyZiNFQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/blocks": "^15.27.0",
+        "@wordpress/data": "^10.54.0",
+        "@wordpress/i18n": "^6.27.0",
+        "@wordpress/private-apis": "^1.54.0",
+        "@wordpress/style-engine": "^2.54.0",
+        "colord": "^2.9.3",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "is-plain-object": "^5.1.0",
+        "memize": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/hooks": {
@@ -9444,6 +10226,51 @@
         }
       }
     },
+    "node_modules/@wordpress/image-cropper": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/image-cropper/-/image-cropper-1.18.0.tgz",
+      "integrity": "sha512-5pZG9fUT1+KPqGT5ovxOORS3pglRqs4v+X2DTPWGF/wWxbT+cS2UIM/n/VHEilKffLH9SnVK5++aAbsnbIob7Q==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/components": "^40.0.0",
+        "@wordpress/element": "^8.6.0",
+        "@wordpress/i18n": "^6.27.0",
+        "clsx": "^2.1.1",
+        "dequal": "^2.0.3",
+        "react-easy-crop": "^5.4.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/interactivity": {
+      "version": "6.54.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.54.0.tgz",
+      "integrity": "sha512-4/nfcysWRH52lGDMrnltJ1PC8JJmAmGQzuO+zUu7lOosINK6h0xyMNeh0mwTrP78eRfQtyL4lDT7s5tGwwnRbA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@preact/signals": "^1.3.0",
+        "@preact/signals-core": "^1.7.0",
+        "preact": "^10.29.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
     "node_modules/@wordpress/is-shallow-equal": {
       "version": "5.54.0",
       "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.54.0.tgz",
@@ -9507,6 +10334,31 @@
         "npm": ">=10.2.3"
       }
     },
+    "node_modules/@wordpress/keyboard-shortcuts": {
+      "version": "5.54.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.54.0.tgz",
+      "integrity": "sha512-EiguLibri6ZBjQHe7rqumTFk5eZrw47Y2m7TuXro08FQS+qxY6YsYlefbCfWBehFIiptYkaZ0OyRu2KhmDOwuA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/data": "^10.54.0",
+        "@wordpress/element": "^8.6.0",
+        "@wordpress/keycodes": "^4.54.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@wordpress/keycodes": {
       "version": "4.54.0",
       "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.54.0.tgz",
@@ -9522,6 +10374,32 @@
       },
       "peerDependencies": {
         "@types/react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/notices": {
+      "version": "5.54.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.54.0.tgz",
+      "integrity": "sha512-fZcDoJEOdRwVtL8pUWVuK7ggNIivMd46/jczxhsX+LmSVT/vlhrBEKv22IeiqpcyGRY8GakXfcK7c02n61HLVw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/a11y": "^4.54.0",
+        "@wordpress/components": "^40.0.0",
+        "@wordpress/data": "^10.54.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -9561,6 +10439,40 @@
       },
       "peerDependencies": {
         "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/@wordpress/preferences": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.54.0.tgz",
+      "integrity": "sha512-yFEJopdYAE0KmlrqrZxfTcwS8rSJcHV+qYfzFlz8pHgZe2UVB5MENPKJetPT7fhM4uN5WISY9cgnEniF3+EoDw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/a11y": "^4.54.0",
+        "@wordpress/base-styles": "^13.0.0",
+        "@wordpress/components": "^40.0.0",
+        "@wordpress/compose": "^8.7.0",
+        "@wordpress/data": "^10.54.0",
+        "@wordpress/deprecated": "^4.54.0",
+        "@wordpress/element": "^8.6.0",
+        "@wordpress/i18n": "^6.27.0",
+        "@wordpress/icons": "^15.5.0",
+        "@wordpress/private-apis": "^1.54.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@wordpress/prettier-config": {
@@ -10044,6 +10956,74 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@wordpress/server-side-render": {
+      "version": "6.30.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-6.30.0.tgz",
+      "integrity": "sha512-AafaeSWKTZr78BrYSoSeApMDAFgZBwqjdUI0rftIZwP3F7cx+Ajal9TzVnWNFobuCMCQzbPtBL9RMJjw2DjZ6A==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/api-fetch": "^7.54.0",
+        "@wordpress/blocks": "^15.27.0",
+        "@wordpress/components": "^40.0.0",
+        "@wordpress/compose": "^8.7.0",
+        "@wordpress/data": "^10.54.0",
+        "@wordpress/deprecated": "^4.54.0",
+        "@wordpress/element": "^8.6.0",
+        "@wordpress/i18n": "^6.27.0",
+        "@wordpress/url": "^4.54.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/shortcode": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.54.0.tgz",
+      "integrity": "sha512-Lt0BzcnaCRH5vIlYHtXN3PHrq1Fc04WC4mhITctUoJeV8hQFpbuQAUKaFrKUTn2jCcQclYKRC8aUVabld8AmcA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "memize": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/style-engine": {
+      "version": "2.54.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.54.0.tgz",
+      "integrity": "sha512-CpZaTUFZovM1X7E884eylSmjufEHBtCzrskCnI0kyCy4N2I+it7B3xAF16qlVVch1QAq0WEvfUhm1phFiaMEXA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "change-case": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@wordpress/style-runtime": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.10.0.tgz",
@@ -10076,7 +11056,7 @@
         "stylelint-scss": "^6.4.0"
       }
     },
-    "node_modules/@wordpress/theme": {
+    "node_modules/@wordpress/stylelint-config/node_modules/@wordpress/theme": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-2.0.0.tgz",
       "integrity": "sha512-4yFei1ayJinMOVY6cTzKZV961p2Vjex9Nst1SReIFKv3ckb6ih5QN+qMpJQdpuukwabXrBTaoiA4ZB1akl2CfQ==",
@@ -10122,6 +11102,17 @@
         }
       }
     },
+    "node_modules/@wordpress/token-list": {
+      "version": "3.54.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.54.0.tgz",
+      "integrity": "sha512-U3LMm0zq35H+kmAVv2bwG8W75sflglI45YLV/KPLGMZIv/f45LTtMkzpJ16c3TSYs0CP+slsV4YIMttetcQwPg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
     "node_modules/@wordpress/ui": {
       "version": "0.21.0",
       "resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.21.0.tgz",
@@ -10161,6 +11152,52 @@
         }
       }
     },
+    "node_modules/@wordpress/ui/node_modules/@wordpress/theme": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-2.0.0.tgz",
+      "integrity": "sha512-4yFei1ayJinMOVY6cTzKZV961p2Vjex9Nst1SReIFKv3ckb6ih5QN+qMpJQdpuukwabXrBTaoiA4ZB1akl2CfQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/compose": "^8.7.0",
+        "@wordpress/deprecated": "^4.54.0",
+        "@wordpress/element": "^8.6.0",
+        "@wordpress/private-apis": "^1.54.0",
+        "@wordpress/style-runtime": "^0.10.0",
+        "colorjs.io": "^0.7.1",
+        "memize": "^2.1.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.13.0",
+        "npm": ">=10.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "esbuild": ">=0.27.2 <1.0.0",
+        "postcss": "^8.0.0",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19",
+        "stylelint": "^16 || ^17",
+        "vite": "^7 || ^8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "stylelint": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@wordpress/undo-manager": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.54.0.tgz",
@@ -10173,6 +11210,54 @@
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/upload-media": {
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.39.0.tgz",
+      "integrity": "sha512-SL5cCERYah4KoF/yviarLEOYw3dH8z0UA78tWFAaR3f+uja2mj92Ub59kRBDnCLrn0SWInW+JbMwWM5mkQRhbw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/blob": "^4.54.0",
+        "@wordpress/compose": "^8.7.0",
+        "@wordpress/data": "^10.54.0",
+        "@wordpress/element": "^8.6.0",
+        "@wordpress/i18n": "^6.27.0",
+        "@wordpress/preferences": "^4.54.0",
+        "@wordpress/private-apis": "^1.54.0",
+        "@wordpress/url": "^4.54.0",
+        "@wordpress/video-conversion": "^0.5.0",
+        "@wordpress/vips": "^4.0.0",
+        "uuid": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/upload-media/node_modules/uuid": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.2.tgz",
+      "integrity": "sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/@wordpress/url": {
@@ -10189,12 +11274,67 @@
         "npm": ">=8.19.2"
       }
     },
+    "node_modules/@wordpress/video-conversion": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/video-conversion/-/video-conversion-0.5.0.tgz",
+      "integrity": "sha512-WM9DLabhL0L/ZNZtrdRotRuFsfMFiMhrEWxUxP1bQoP7ln0wfqq9WubR+PKR5y3DN8k2xgqi2ChHUemZHANUKw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/worker-threads": "^1.14.0",
+        "mediabunny": "^1.45.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/vips": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/vips/-/vips-4.0.0.tgz",
+      "integrity": "sha512-ArVropSpPfvB8AbqKtBcW1qG//yevwObABjDCKFN2ym0XA7xVcgwWy48MzFdQMDJ3RCf5q1iButc4n0Tk2Tf1w==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/worker-threads": "^1.14.0",
+        "wasm-vips": "^0.0.18"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
     "node_modules/@wordpress/warning": {
       "version": "3.54.0",
       "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.54.0.tgz",
       "integrity": "sha512-0QWxBc/CHQdgzTwnUg+Ha5Ir0qyuIQUDzA2gmGSbbVshgm3d5FugLGpZHL1/S2+KlczyjKS2fftDJmK1dxdsEg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/wordcount": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.54.0.tgz",
+      "integrity": "sha512-hITSDjfFELk0n3ZzajvJRO6WjRN3+UM9P3ApL37kaNMV54HHLJRSEhzRbQJEcrRqkMrd6uMRmpCbrH0BB6lZPQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/worker-threads": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/worker-threads/-/worker-threads-1.14.0.tgz",
+      "integrity": "sha512-jcJoMirVeEVtM+PC1gnqmgvRBd72rzgsaAb17Pzz0q8FBK/Kn6/bNhaWXMLQG8bVCeF5Ot2pDqnPmmi2Rj0qsQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "comctx": "^1.4.3"
+      },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
@@ -10672,6 +11812,19 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
@@ -10981,6 +12134,13 @@
       "peerDependencies": {
         "postcss": "^8.1.0"
       }
+    },
+    "node_modules/autosize": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/autosize/-/autosize-4.0.4.tgz",
+      "integrity": "sha512-5yxLQ22O0fCRGoxGfeLSNt3J8LB1v+umtpMnPW6XjkTWXKoN0AmXAIhelJcDtFT/Y/wYWmfE+oqU10Q0b8FhaQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -12198,6 +13358,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -12260,6 +13437,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/color"
       }
+    },
+    "node_modules/comctx": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/comctx/-/comctx-1.7.5.tgz",
+      "integrity": "sha512-0fsxsxr1Hg2T99wOIteUbsJOX6jMmnhAJepcVRqNRMWpcbxRhbm2+0R8qEuQEaE4gWjfdXaKeAGYAn0yeElylQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "9.0.0",
@@ -12346,6 +13530,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/computed-style": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/computed-style/-/computed-style-0.1.4.tgz",
+      "integrity": "sha512-WpAmaKbMNmS3OProfHIdJiNleNJdgUrJfbKArXua28QF7+0CoZjlLn0lp6vlc+dl5r2/X9GQiQRQQU4BzSa69w==",
+      "dev": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -13265,7 +14455,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -13308,12 +14497,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/devtools-protocol": {
       "version": "0.0.1507524",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1507524.tgz",
       "integrity": "sha512-OjaNE7qpk6GRTXtqQjAE5bGx6+c4F1zZH0YXtpZQLM92HNXx4zMAaqlKhP4T52DosG6hDW8gPMNhGOF8xbwk/w==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/diff3": {
       "version": "0.0.3",
@@ -15527,6 +16733,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -16198,6 +17414,13 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/hpq": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/hpq/-/hpq-1.4.0.tgz",
+      "integrity": "sha512-ycJQMRaRPBcfnoT1gS5I1XCvbbw9KO94Y0vkwksuOjcJMqNZtb03MF2tCItLI2mQbkZWSSeFinoRDPmjzv4tKg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
@@ -18525,6 +19748,19 @@
         "url": "https://github.com/sponsors/antonk52"
       }
     },
+    "node_modules/line-height": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/line-height/-/line-height-0.3.1.tgz",
+      "integrity": "sha512-YExecgqPwnp5gplD2+Y8e8A5+jKpr25+DzMbFdI1/1UAr0FJrTFv4VkHLf8/6B590i1wUPJWMKKldkd/bdQ//w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "computed-style": "~0.1.3"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -18963,6 +20199,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/marked": {
+      "version": "18.0.11",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.11.tgz",
+      "integrity": "sha512-HnslJfsZkRPBDJRHvVtAaWlZHEpSu7u8LgQuJCELjRKuWR+hpq4A7sLq3p8HaI9ypVoXDXxV34CsQJEe1+J5Aw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/marky": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
@@ -19013,6 +20262,25 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mediabunny": {
+      "version": "1.55.6",
+      "resolved": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.55.6.tgz",
+      "integrity": "sha512-IuwxlL8GQ5qODxvdj0mm5bUumrwTr13ooX0UygsrT2u1uwERjV1Awv/zuFoY5iNeYic6SQU78BcGcGLnDgPQ9g==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "workspaces": [
+        ".",
+        "packages/*"
+      ],
+      "dependencies": {
+        "@types/dom-mediacapture-transform": "^0.1.11",
+        "@types/dom-webcodecs": "0.1.13"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/Vanilagy"
       }
     },
     "node_modules/memfs": {
@@ -19707,6 +20975,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/normalize-wheel": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
+      "integrity": "sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/npm-bundled": {
       "version": "1.1.2",
@@ -20553,6 +21828,23 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/parsel-js": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/parsel-js/-/parsel-js-1.2.3.tgz",
+      "integrity": "sha512-kJHFmSNnujpusFfVEXjNaoJ09VYHF8Ih0aVUn7Clu+Ug8AFoA2wx7Ezh17JfW4+vhm/lauAd9A+//uFkmydZtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/LeaVerou"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/leaverou"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -21522,6 +22814,16 @@
         "postcss": "^8.4.31"
       }
     },
+    "node_modules/postcss-prefix-selector": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/postcss-prefix-selector/-/postcss-prefix-selector-1.16.1.tgz",
+      "integrity": "sha512-Umxu+FvKMwlY6TyDzGFoSUnzW+NOfMBLyC1tAkIjgX+Z/qGspJeRjVC903D7mx7TuBpJlwti2ibXtWuA7fKMeQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "postcss": ">4 <9"
+      }
+    },
     "node_modules/postcss-reduce-initial": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-6.1.0.tgz",
@@ -21663,6 +22965,19 @@
         "postcss": "^8.4.31"
       }
     },
+    "node_modules/postcss-urlrebase": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/postcss-urlrebase/-/postcss-urlrebase-1.4.0.tgz",
+      "integrity": "sha512-rRaxMmWvXrn8Rk1PqsxmaJwldRHsr0WbbASKKCZYxXwotHkM/5X/6IrwaEe8pdzpbNGCEY86yhYMN0MhgOkADA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3.0"
+      }
+    },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
@@ -21711,6 +23026,25 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.8",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.8.tgz",
+      "integrity": "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
       }
     },
     "node_modules/prelude-ls": {
@@ -22088,20 +23422,22 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
-      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-colorful": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.8.0.tgz",
-      "integrity": "sha512-Wy9OzPfjSN9bF12OB8N7UQvlsZ0I+7wHxpN+bV5BjNQGxOj6IiwkRjevJK9yOBjJWGQvAaf1OXtn8rUeEatAng==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.8.1.tgz",
+      "integrity": "sha512-oz68bhsnFWnpDf1ZR8daiQbYpXUnM2h2J6hl9Zg2rTpM/DU6vCqe1E+CpqmqLnJucMZetHZeifSAfJ+geN9lcA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -22137,17 +23473,33 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
-      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "scheduler": "^0.27.0"
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
       },
       "peerDependencies": {
-        "react": "^19.2.8"
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-easy-crop": {
+      "version": "5.5.7",
+      "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.5.7.tgz",
+      "integrity": "sha512-kYo4NtMeXFQB7h1U+h5yhUkE46WQbQdq7if54uDlbMdZHdRgNehfvaFrXnFw5NR1PNoUOJIfTwLnWmEx/MaZnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "normalize-wheel": "^1.0.1",
+        "tslib": "^2.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.4.0",
+        "react-dom": ">=16.4.0"
       }
     },
     "node_modules/react-is": {
@@ -22165,6 +23517,78 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/read-cache": {
@@ -23002,12 +24426,15 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
     },
     "node_modules/schema-utils": {
       "version": "4.3.3",
@@ -23516,6 +24943,13 @@
         "type": "github",
         "url": "https://github.com/steveukx/git-js?sponsor=1"
       }
+    },
+    "node_modules/simple-html-tokenizer": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz",
+      "integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sirv": {
       "version": "2.0.4",
@@ -25798,6 +27232,51 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
@@ -25912,6 +27391,16 @@
       "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/wasm-vips": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/wasm-vips/-/wasm-vips-0.0.18.tgz",
+      "integrity": "sha512-AJyCvxZj/3qceKNnh+YyEobu/IaJFoPN7x7SxyyHmYBS3kASMqJqxQEuN0ZHKQDWsCJ8armfx4Tq3uKrNc+nMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=17.0.0"
+      }
     },
     "node_modules/watchpack": {
       "version": "2.5.2",

--- a/package.json
+++ b/package.json
@@ -61,12 +61,15 @@
     "@testing-library/react": "^16.3.3",
     "@testing-library/user-event": "^14.6.6",
     "@wordpress/api-fetch": "^7.54.0",
+    "@wordpress/block-editor": "^17.0.0",
+    "@wordpress/blocks": "^15.27.0",
     "@wordpress/components": "^40.0.0",
     "@wordpress/e2e-test-utils-playwright": "^1.54.0",
     "@wordpress/element": "^8.6.0",
     "@wordpress/env": "^11.14.0",
     "@wordpress/i18n": "^6.27.0",
     "@wordpress/jest-console": "^9.2.0",
-    "@wordpress/scripts": "^34.2.0"
+    "@wordpress/scripts": "^34.2.0",
+    "@wordpress/server-side-render": "^6.30.0"
   }
 }

--- a/src/blocks/README.md
+++ b/src/blocks/README.md
@@ -15,6 +15,11 @@ src/blocks/event-card/
 That builds to `build/blocks/event-card/`, and `Traktivity_Blocks` registers
 whatever it finds there.
 
+`webpack.config.js` exists because of one of these: wp-scripts builds either the
+blocks it finds or the default `src/index.js`, never both, so the dashboard entry
+has to be put back by hand. Adding a block does not need that file changed, but
+deleting it would take the dashboard bundle with it.
+
 Two things the build decides for you, both verified rather than assumed:
 
 - The stylesheet comes out as `style-index.css`, because webpack names it after
@@ -22,6 +27,10 @@ Two things the build decides for you, both verified rather than assumed:
   `"style": [ "traktivity-shared", "file:./style-index.css" ]`, not `style.css`.
 - `render.php` is copied across as-is, so `"render": "file:./render.php"` works
   from the built directory.
+
+`Traktivity_Blocks::frame()` renders artwork inside a fixed-ratio frame and falls
+back to `Traktivity_Blocks::placeholder()` when there is none, which is the
+normal case often enough to matter. Use them rather than writing an `<img>`.
 
 `traktivity-shared` carries the media frame and the missing-artwork placeholder,
 which four blocks reuse. List it first, then the block's own stylesheet; a page

--- a/src/blocks/event-card/block.json
+++ b/src/blocks/event-card/block.json
@@ -1,0 +1,39 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "traktivity/event-card",
+	"title": "Event Card",
+	"category": "traktivity",
+	"icon": "video-alt2",
+	"description": "One watch event, with its show and episode number restored from the taxonomies.",
+	"textdomain": "traktivity",
+	"usesContext": [ "postId", "postType" ],
+	"attributes": {
+		"imageAspect": { "type": "string", "default": "landscape" },
+		"showImage": { "type": "boolean", "default": true },
+		"showExcerpt": { "type": "boolean", "default": false },
+		"headingLevel": { "type": "number", "default": 3 }
+	},
+	"supports": {
+		"html": false,
+		"reusable": false,
+		"align": false,
+		"color": {
+			"background": true,
+			"text": true,
+			"link": true
+		},
+		"spacing": {
+			"padding": true,
+			"margin": true,
+			"blockGap": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true
+		}
+	},
+	"editorScript": "file:./index.js",
+	"style": [ "traktivity-shared", "file:./style-index.css" ],
+	"render": "file:./render.php"
+}

--- a/src/blocks/event-card/index.js
+++ b/src/blocks/event-card/index.js
@@ -1,0 +1,109 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	PanelBody,
+	RangeControl,
+	SelectControl,
+	ToggleControl,
+} from '@wordpress/components';
+import ServerSideRender from '@wordpress/server-side-render';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import './style.scss';
+
+/**
+ * Preview the card the way the front end will render it.
+ *
+ * The card is composed from six taxonomies and some post meta, none of which
+ * the editor has to hand, so ServerSideRender is the only way to show what a
+ * reader will actually see rather than a guess at it.
+ *
+ * @param {Object}   props               Block props.
+ * @param {Object}   props.attributes    Block attributes.
+ * @param {Function} props.setAttributes Attribute setter.
+ * @param {Object}   props.context       Block context, carrying the post ID.
+ * @return {Element} The editor preview.
+ */
+function Edit( { attributes, setAttributes, context } ) {
+	const blockProps = useBlockProps();
+
+	return (
+		<div { ...blockProps }>
+			<InspectorControls>
+				<PanelBody title={ __( 'Card', 'traktivity' ) }>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Show artwork', 'traktivity' ) }
+						checked={ attributes.showImage }
+						onChange={ ( showImage ) =>
+							setAttributes( { showImage } )
+						}
+					/>
+					{ attributes.showImage && (
+						<SelectControl
+							__nextHasNoMarginBottom
+							label={ __( 'Artwork shape', 'traktivity' ) }
+							help={ __(
+								'Artwork comes from TMDb as a 16:9 still. A portrait frame crops it.',
+								'traktivity'
+							) }
+							value={ attributes.imageAspect }
+							options={ [
+								{
+									label: __( 'Landscape', 'traktivity' ),
+									value: 'landscape',
+								},
+								{
+									label: __( 'Portrait', 'traktivity' ),
+									value: 'poster',
+								},
+							] }
+							onChange={ ( imageAspect ) =>
+								setAttributes( { imageAspect } )
+							}
+						/>
+					) }
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Show summary', 'traktivity' ) }
+						checked={ attributes.showExcerpt }
+						onChange={ ( showExcerpt ) =>
+							setAttributes( { showExcerpt } )
+						}
+					/>
+					<RangeControl
+						__nextHasNoMarginBottom
+						label={ __( 'Heading level', 'traktivity' ) }
+						help={ __(
+							'Pick the level that follows the heading above this block.',
+							'traktivity'
+						) }
+						min={ 1 }
+						max={ 6 }
+						value={ attributes.headingLevel }
+						onChange={ ( headingLevel ) =>
+							setAttributes( { headingLevel: headingLevel || 3 } )
+						}
+					/>
+				</PanelBody>
+			</InspectorControls>
+
+			<ServerSideRender
+				block={ metadata.name }
+				attributes={ attributes }
+				urlQueryArgs={
+					context?.postId ? { post_id: context.postId } : {}
+				}
+			/>
+		</div>
+	);
+}
+
+registerBlockType( metadata.name, { edit: Edit } );

--- a/src/blocks/event-card/render.php
+++ b/src/blocks/event-card/render.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Render the Event Card block.
+ *
+ * @package Traktivity
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block default content.
+ * @var WP_Block $block      Block instance.
+ */
+
+declare( strict_types = 1 );
+
+defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
+
+$traktivity_post_id = isset( $block->context['postId'] ) ? (int) $block->context['postId'] : (int) get_the_ID();
+
+if ( $traktivity_post_id < 1 ) {
+	return;
+}
+
+$traktivity_event = traktivity_get_event( $traktivity_post_id );
+
+if ( '' === $traktivity_event['type'] ) {
+	return;
+}
+
+$traktivity_aspect = isset( $attributes['imageAspect'] ) && 'poster' === $attributes['imageAspect'] ? 'poster' : 'landscape';
+$traktivity_level  = isset( $attributes['headingLevel'] ) ? min( 6, max( 1, (int) $attributes['headingLevel'] ) ) : 3;
+$traktivity_tag    = 'h' . $traktivity_level;
+
+/*
+ * On a single show's archive every card would repeat the same show name, so
+ * the kicker is dropped there and the episode code carries the row instead.
+ */
+$traktivity_queried = get_queried_object();
+if ( $traktivity_queried instanceof WP_Term && 'trakt_show' === $traktivity_queried->taxonomy ) {
+	$traktivity_event['show_name'] = '';
+}
+
+$traktivity_wrapper = get_block_wrapper_attributes(
+	array( 'class' => 'traktivity-card traktivity-card--' . $traktivity_event['type'] )
+);
+?>
+<article <?php echo $traktivity_wrapper; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Prepared by get_block_wrapper_attributes(). ?>>
+	<?php if ( ! empty( $attributes['showImage'] ) ) : ?>
+		<?php
+		/*
+		 * The title below links to the same place. Without this the keyboard
+		 * lands on the same destination twice per card, which on a 24-card
+		 * archive is 24 wasted tab stops.
+		 */
+		?>
+		<a class="traktivity-card__link" href="<?php echo esc_url( $traktivity_event['permalink'] ); ?>" tabindex="-1" aria-hidden="true">
+			<?php echo Traktivity_Blocks::frame( $traktivity_event['image_id'], $traktivity_event['title'], $traktivity_aspect ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped in Traktivity_Blocks::frame(). ?>
+		</a>
+	<?php endif; ?>
+
+	<div class="traktivity-card__body">
+		<?php if ( '' !== $traktivity_event['show_name'] ) : ?>
+			<p class="traktivity-card__show">
+				<?php if ( '' !== $traktivity_event['show_link'] ) : ?>
+					<a href="<?php echo esc_url( $traktivity_event['show_link'] ); ?>"><?php echo esc_html( $traktivity_event['show_name'] ); ?></a>
+				<?php else : ?>
+					<?php echo esc_html( $traktivity_event['show_name'] ); ?>
+				<?php endif; ?>
+			</p>
+		<?php endif; ?>
+
+		<<?php echo esc_html( $traktivity_tag ); ?> class="traktivity-card__title">
+			<a href="<?php echo esc_url( $traktivity_event['permalink'] ); ?>">
+				<?php if ( '' !== $traktivity_event['episode_code'] ) : ?>
+					<span class="traktivity-card__code"><?php echo esc_html( $traktivity_event['episode_code'] ); ?></span>
+				<?php endif; ?>
+				<?php echo esc_html( $traktivity_event['title'] ); ?>
+			</a>
+		</<?php echo esc_html( $traktivity_tag ); ?>>
+
+		<?php if ( ! empty( $attributes['showExcerpt'] ) ) : ?>
+			<?php $traktivity_excerpt = wp_trim_words( (string) get_the_excerpt( $traktivity_post_id ), 22 ); ?>
+			<?php if ( '' !== $traktivity_excerpt ) : ?>
+				<p class="traktivity-card__excerpt"><?php echo esc_html( $traktivity_excerpt ); ?></p>
+			<?php endif; ?>
+		<?php endif; ?>
+
+		<p class="traktivity-card__meta">
+			<time datetime="<?php echo esc_attr( $traktivity_event['watched_iso'] ); ?>"><?php echo esc_html( $traktivity_event['watched'] ); ?></time>
+
+			<?php if ( $traktivity_event['runtime'] > 0 ) : ?>
+				<span class="traktivity-sep" aria-hidden="true">&middot;</span>
+				<?php
+				printf(
+					/* translators: %d: number of minutes. */
+					esc_html( _n( '%d min', '%d min', $traktivity_event['runtime'], 'traktivity' ) ),
+					(int) $traktivity_event['runtime']
+				);
+				?>
+			<?php endif; ?>
+
+			<?php if ( 'movie' === $traktivity_event['type'] && '' !== $traktivity_event['year'] ) : ?>
+				<span class="traktivity-sep" aria-hidden="true">&middot;</span>
+				<?php echo esc_html( $traktivity_event['year'] ); ?>
+			<?php endif; ?>
+		</p>
+	</div>
+</article>

--- a/src/blocks/event-card/style.scss
+++ b/src/blocks/event-card/style.scss
@@ -1,0 +1,49 @@
+/**
+ * Event Card.
+ *
+ * The frame and the missing-artwork placeholder come from the shared
+ * stylesheet; everything here is the card itself.
+ */
+
+.traktivity-card {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5em;
+}
+
+.traktivity-card__link {
+	display: block;
+	text-decoration: none;
+}
+
+.traktivity-card__body {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25em;
+}
+
+.traktivity-card__show {
+	font-size: var(--wp--preset--font-size--small, 0.8125rem);
+	letter-spacing: 0.06em;
+	margin: 0;
+	text-transform: uppercase;
+}
+
+.traktivity-card__title {
+	margin: 0;
+}
+
+.traktivity-card__code {
+	opacity: 0.7;
+	white-space: nowrap;
+}
+
+.traktivity-card__excerpt {
+	margin: 0;
+}
+
+.traktivity-card__meta {
+	font-size: var(--wp--preset--font-size--small, 0.8125rem);
+	margin: 0;
+	opacity: 0.75;
+}

--- a/tests/package/verify-package.mjs
+++ b/tests/package/verify-package.mjs
@@ -95,6 +95,15 @@ for ( const required of [
 	'build/style-index.css',
 	// Shared by several blocks; a block.json naming the handle needs it present.
 	'assets/blocks-shared.css',
+	/*
+	 * A block entry and the dashboard entry are easy to lose at the same time:
+	 * wp-scripts builds either the blocks it finds or the default src/index.js,
+	 * never both, so one of these disappearing is the signal that the entry
+	 * list in webpack.config.js needs looking at.
+	 */
+	'build/blocks/event-card/block.json',
+	'build/blocks/event-card/render.php',
+	'build/blocks/event-card/style-index.css',
 ] ) {
 	check( has( required ), `ships ${ required }` );
 }

--- a/tests/php/EventCardBlockTest.php
+++ b/tests/php/EventCardBlockTest.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * Tests for the Event Card block.
+ *
+ * @package Traktivity
+ */
+
+/**
+ * Rendering one watch event as a card.
+ */
+class EventCardBlockTest extends WP_UnitTestCase {
+
+	/**
+	 * Register the block from its built directory, if there is one.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$built = TRAKTIVITY__PLUGIN_DIR . 'build/blocks/event-card';
+
+		if ( ! WP_Block_Type_Registry::get_instance()->is_registered( 'traktivity/event-card' ) && is_dir( $built ) ) {
+			register_block_type( $built );
+		}
+	}
+
+	/**
+	 * Build an event the way the sync would.
+	 *
+	 * @param array $meta       Post meta.
+	 * @param array $taxonomies Terms, keyed by taxonomy.
+	 * @param array $postarr    Overrides for the post.
+	 *
+	 * @return int Post ID.
+	 */
+	private function make_event( array $meta, array $taxonomies = array(), array $postarr = array() ) {
+		$post_id = self::factory()->post->create(
+			array_merge(
+				array(
+					'post_type'  => 'traktivity_event',
+					'post_title' => 'Episode Name',
+				),
+				$postarr
+			)
+		);
+
+		foreach ( $meta as $key => $value ) {
+			update_post_meta( $post_id, $key, $value );
+		}
+
+		// Always an array: a bare "0" reads as empty to wp_set_object_terms(). See #702.
+		foreach ( $taxonomies as $taxonomy => $terms ) {
+			wp_set_object_terms( $post_id, (array) $terms, $taxonomy );
+		}
+
+		return $post_id;
+	}
+
+	/**
+	 * Render the card against a post.
+	 *
+	 * Render_block() takes block context from the global post rather than from
+	 * the parsed block, so the post has to be staged there.
+	 *
+	 * @param int   $post_id Post to render against.
+	 * @param array $attrs   Block attributes.
+	 *
+	 * @return string Rendered HTML.
+	 */
+	private function render( $post_id, array $attrs = array() ) {
+		$previous        = isset( $GLOBALS['post'] ) ? $GLOBALS['post'] : null;
+		$GLOBALS['post'] = get_post( $post_id );
+
+		$html = render_block(
+			array(
+				'blockName'    => 'traktivity/event-card',
+				'attrs'        => $attrs,
+				'innerHTML'    => '',
+				'innerBlocks'  => array(),
+				'innerContent' => array(),
+			)
+		);
+
+		$GLOBALS['post'] = $previous;
+
+		return $html;
+	}
+
+	/**
+	 * A TV episode shows its show, code, title and runtime.
+	 */
+	public function test_tv_card() {
+		$post_id = $this->make_event(
+			array(
+				'trakt_show_id' => 1,
+				'trakt_runtime' => 60,
+			),
+			array(
+				'trakt_show'    => 'Some Show',
+				'trakt_season'  => '3',
+				'trakt_episode' => '2',
+			)
+		);
+
+		$html = $this->render( $post_id );
+
+		$this->assertStringContainsString( 'Some Show', $html );
+		$this->assertStringContainsString( 'S3E2', $html );
+		$this->assertStringContainsString( 'Episode Name', $html );
+		$this->assertStringContainsString( '60 min', $html );
+		$this->assertStringContainsString( 'traktivity-card--tv', $html );
+	}
+
+	/**
+	 * A movie shows its year and no episode code.
+	 */
+	public function test_movie_card() {
+		$post_id = $this->make_event(
+			array(
+				'trakt_movie_id' => 2,
+				'trakt_runtime'  => 105,
+			),
+			array( 'trakt_year' => '2019' ),
+			array( 'post_title' => 'A Film' )
+		);
+
+		$html = $this->render( $post_id );
+
+		$this->assertStringContainsString( 'A Film', $html );
+		$this->assertStringContainsString( '2019', $html );
+		$this->assertStringContainsString( 'traktivity-card--movie', $html );
+		$this->assertStringNotContainsString( 'traktivity-card__code', $html );
+		$this->assertStringNotContainsString( 'S0E0', $html );
+	}
+
+	/**
+	 * An event with no artwork gets the placeholder rather than a broken frame.
+	 */
+	public function test_missing_artwork_falls_back() {
+		$post_id = $this->make_event( array( 'trakt_show_id' => 3 ) );
+
+		$html = $this->render( $post_id );
+
+		$this->assertStringContainsString( 'traktivity-frame--empty', $html );
+		$this->assertStringContainsString( 'No artwork', $html );
+		$this->assertStringNotContainsString( '<img', $html );
+	}
+
+	/**
+	 * The image link is skipped by the keyboard.
+	 *
+	 * It points at the same place as the title, so without this every card
+	 * costs two tab stops for one destination.
+	 */
+	public function test_image_link_is_not_a_second_tab_stop() {
+		$post_id = $this->make_event( array( 'trakt_show_id' => 4 ) );
+
+		$html = $this->render( $post_id );
+
+		$this->assertStringContainsString( 'tabindex="-1"', $html );
+		$this->assertStringContainsString( 'aria-hidden="true"', $html );
+	}
+
+	/**
+	 * Artwork can be turned off entirely.
+	 */
+	public function test_artwork_can_be_hidden() {
+		$post_id = $this->make_event( array( 'trakt_show_id' => 5 ) );
+
+		$html = $this->render( $post_id, array( 'showImage' => false ) );
+
+		$this->assertStringNotContainsString( 'traktivity-frame', $html );
+		$this->assertStringContainsString( 'Episode Name', $html );
+	}
+
+	/**
+	 * The heading level is configurable, and clamped to something valid.
+	 */
+	public function test_heading_level() {
+		$post_id = $this->make_event( array( 'trakt_show_id' => 6 ) );
+
+		$this->assertStringContainsString( '<h2 class="traktivity-card__title"', $this->render( $post_id, array( 'headingLevel' => 2 ) ) );
+		$this->assertStringContainsString( '<h6 class="traktivity-card__title"', $this->render( $post_id, array( 'headingLevel' => 99 ) ) );
+		$this->assertStringContainsString( '<h1 class="traktivity-card__title"', $this->render( $post_id, array( 'headingLevel' => -4 ) ) );
+	}
+
+	/**
+	 * The show name is dropped on that show's own archive.
+	 *
+	 * Every card there would otherwise repeat the same name.
+	 */
+	public function test_show_name_dropped_on_a_show_archive() {
+		$post_id = $this->make_event(
+			array( 'trakt_show_id' => 7 ),
+			array(
+				'trakt_show'    => 'Some Show',
+				'trakt_season'  => '1',
+				'trakt_episode' => '1',
+			)
+		);
+
+		$term = get_term_by( 'name', 'Some Show', 'trakt_show' );
+
+		$previous_query                         = $GLOBALS['wp_query'];
+		$GLOBALS['wp_query']                    = new WP_Query();
+		$GLOBALS['wp_query']->is_tax            = true;
+		$GLOBALS['wp_query']->queried_object    = $term;
+		$GLOBALS['wp_query']->queried_object_id = $term->term_id;
+
+		$html = $this->render( $post_id );
+
+		$GLOBALS['wp_query'] = $previous_query;
+
+		$this->assertStringNotContainsString( 'traktivity-card__show', $html );
+		$this->assertStringContainsString( 'S1E1', $html );
+	}
+
+	/**
+	 * A post that is not an event renders nothing.
+	 */
+	public function test_other_post_types_render_nothing() {
+		$post_id = self::factory()->post->create();
+
+		$this->assertSame( '', trim( $this->render( $post_id ) ) );
+	}
+
+	/**
+	 * An empty summary does not leave an empty paragraph behind.
+	 */
+	public function test_empty_excerpt_is_not_rendered() {
+		$post_id = $this->make_event(
+			array( 'trakt_show_id' => 8 ),
+			array(),
+			array(
+				'post_content' => '',
+				'post_excerpt' => '',
+			)
+		);
+
+		$this->assertStringNotContainsString( 'traktivity-card__excerpt', $this->render( $post_id, array( 'showExcerpt' => true ) ) );
+	}
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,27 @@
+/**
+ * Build configuration.
+ *
+ * wp-scripts builds either the blocks it finds or a default `src/index.js`
+ * entry, not both: as soon as a `block.json` appears under `src/`, its entry
+ * list becomes the blocks alone and the dashboard bundle silently stops being
+ * emitted. This puts the dashboard entry back alongside the blocks.
+ *
+ * Everything else is left to the default config.
+ */
+const path = require( 'path' );
+const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
+
+module.exports = {
+	...defaultConfig,
+	entry: () => {
+		const blockEntries =
+			typeof defaultConfig.entry === 'function'
+				? defaultConfig.entry()
+				: defaultConfig.entry;
+
+		return {
+			...blockEntries,
+			index: path.resolve( process.cwd(), 'src', 'index.js' ),
+		};
+	},
+};


### PR DESCRIPTION
Fixes #690

## What it does

The first block: one watch event rendered as a card, for use inside a Query Loop.
Show name, episode code, title, watch date, runtime, and the release year for
films.

Attributes for artwork on/off, landscape or portrait, a summary, and the heading
level.

## Rationale

A Query Loop over `traktivity_event` posts built from core blocks gives you a
list of bare episode names. Post Title prints "Episode Name" with nothing saying
which show it belongs to, and Post Excerpt has nothing useful to add. This is the
block that makes such a loop worth having.

Details worth calling out:

- **The image link is out of the tab order.** It points at the same place as the
  title, so `tabindex="-1"` and `aria-hidden="true"`. Left in, a 24-card archive
  costs 48 tab stops for 24 destinations.
- **Missing artwork gets a placeholder,** because TMDb doesn't have an image for
  everything and this is a normal state rather than an error. The frame and the
  fallback moved into `Traktivity_Blocks` as static methods, since four blocks
  will want them, and because phpcs won't have a file mixing a class with
  functions.
- **The show name is dropped on that show's own archive,** where every card would
  otherwise repeat it, and the episode code carries the row instead.
- The heading level is clamped to 1-6 rather than trusted.
- An empty summary doesn't leave an empty paragraph behind.

## The build needed fixing

Adding the first `block.json` under `src/` silently stopped the dashboard bundle
from being emitted:

```
FAIL  ships build/index.js
FAIL  ships build/index.asset.php
FAIL  ships build/style-index.css
```

wp-scripts builds either the blocks it finds or the default `src/index.js` entry,
never both. `webpack.config.js` puts the dashboard entry back alongside the
blocks.

The package check now *requires* both the dashboard bundle and the built block,
so losing either fails the build rather than shipping a plugin whose settings
screen is blank. That's the check #689 asked for, now with something real to
check.

`@wordpress/blocks`, `@wordpress/block-editor` and `@wordpress/server-side-render`
are added as devDependencies. They're externalised at build time, but ESLint
resolves imports and won't take them on faith.

The editor preview uses `ServerSideRender`. The card is composed from six
taxonomies and some post meta, none of which the editor has to hand, so anything
else would be a guess at what a reader sees rather than the thing itself.

## Testing

`composer run lint && composer run analyse` clean. PHPUnit 154 passing, 331
assertions. `build`, `test:package`, `lint:js`, `lint:css`, `test:unit` all pass.

New coverage: a TV card, a movie card, missing artwork falling back, the image
link not being a second tab stop, artwork hidden, the heading level being
configurable and clamped at both ends, the show name dropped on a show archive, a
post of the wrong type rendering nothing, and an empty summary leaving no empty
paragraph.
