### PR TITLE
Add an Event Title block, so a heading says what it is about

### DIFF
--- a/src/blocks/event-title/block.json
+++ b/src/blocks/event-title/block.json
@@ -1,0 +1,35 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "traktivity/event-title",
+	"title": "Event Title",
+	"category": "traktivity",
+	"icon": "heading",
+	"description": "The event title, with its show and episode number restored from the taxonomies.",
+	"textdomain": "traktivity",
+	"usesContext": [ "postId", "postType" ],
+	"attributes": {
+		"level": { "type": "number", "default": 1 },
+		"showShowName": { "type": "boolean", "default": true },
+		"linkShowName": { "type": "boolean", "default": true },
+		"isLink": { "type": "boolean", "default": false }
+	},
+	"supports": {
+		"html": false,
+		"reusable": false,
+		"color": {
+			"background": true,
+			"text": true,
+			"link": true
+		},
+		"spacing": { "margin": true, "padding": true },
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"fontWeight": true
+		}
+	},
+	"editorScript": "file:./index.js",
+	"style": [ "traktivity-shared", "file:./style-index.css" ],
+	"render": "file:./render.php"
+}

--- a/src/blocks/event-title/index.js
+++ b/src/blocks/event-title/index.js
@@ -1,0 +1,91 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, RangeControl, ToggleControl } from '@wordpress/components';
+import ServerSideRender from '@wordpress/server-side-render';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import './style.scss';
+
+/**
+ * Preview the composed title.
+ *
+ * The show name and the episode numbers live in three taxonomies the editor
+ * does not have to hand, so the preview is rendered on the server.
+ *
+ * @param {Object}   props               Block props.
+ * @param {Object}   props.attributes    Block attributes.
+ * @param {Function} props.setAttributes Attribute setter.
+ * @param {Object}   props.context       Block context, carrying the post ID.
+ * @return {Element} The editor preview.
+ */
+function Edit( { attributes, setAttributes, context } ) {
+	const blockProps = useBlockProps();
+
+	return (
+		<div { ...blockProps }>
+			<InspectorControls>
+				<PanelBody title={ __( 'Title', 'traktivity' ) }>
+					<RangeControl
+						__nextHasNoMarginBottom
+						label={ __( 'Heading level', 'traktivity' ) }
+						min={ 1 }
+						max={ 6 }
+						value={ attributes.level }
+						onChange={ ( level ) =>
+							setAttributes( { level: level || 1 } )
+						}
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Show the series name', 'traktivity' ) }
+						help={ __(
+							'Turn this off where the series is already named above.',
+							'traktivity'
+						) }
+						checked={ attributes.showShowName }
+						onChange={ ( showShowName ) =>
+							setAttributes( { showShowName } )
+						}
+					/>
+					{ attributes.showShowName && (
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Link the series name', 'traktivity' ) }
+							checked={ attributes.linkShowName }
+							onChange={ ( linkShowName ) =>
+								setAttributes( { linkShowName } )
+							}
+						/>
+					) }
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Link to the entry', 'traktivity' ) }
+						help={ __(
+							'Useful in a listing, not on the entry itself.',
+							'traktivity'
+						) }
+						checked={ attributes.isLink }
+						onChange={ ( isLink ) => setAttributes( { isLink } ) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+
+			<ServerSideRender
+				block={ metadata.name }
+				attributes={ attributes }
+				urlQueryArgs={
+					context?.postId ? { post_id: context.postId } : {}
+				}
+			/>
+		</div>
+	);
+}
+
+registerBlockType( metadata.name, { edit: Edit } );

--- a/src/blocks/event-title/render.php
+++ b/src/blocks/event-title/render.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Render the Event Title block.
+ *
+ * Core's Post Title prints the bare episode name, which identifies nothing on
+ * its own. The show and the episode numbers live in three other taxonomies, so
+ * the heading has to be composed rather than read off the post.
+ *
+ * @package Traktivity
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block default content.
+ * @var WP_Block $block      Block instance.
+ */
+
+declare( strict_types = 1 );
+
+defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
+
+$traktivity_post_id = isset( $block->context['postId'] ) ? (int) $block->context['postId'] : (int) get_the_ID();
+
+if ( $traktivity_post_id < 1 ) {
+	return;
+}
+
+$traktivity_event = traktivity_get_event( $traktivity_post_id );
+
+if ( '' === $traktivity_event['type'] ) {
+	return;
+}
+
+$traktivity_level = isset( $attributes['level'] ) ? min( 6, max( 1, (int) $attributes['level'] ) ) : 1;
+$traktivity_tag   = 'h' . $traktivity_level;
+$traktivity_show  = ! isset( $attributes['showShowName'] ) || $attributes['showShowName'];
+$traktivity_link  = ! isset( $attributes['linkShowName'] ) || $attributes['linkShowName'];
+
+$traktivity_wrapper = get_block_wrapper_attributes( array( 'class' => 'traktivity-event-title' ) );
+
+/*
+ * The parts are assembled here rather than through
+ * traktivity_get_event_title(), which returns plain text by design. A linked
+ * show name needs markup, and building it from the separate show_name and
+ * show_link keys keeps each part escapable on its own.
+ */
+$traktivity_parts = array();
+
+if ( $traktivity_show && '' !== $traktivity_event['show_name'] ) {
+	if ( $traktivity_link && '' !== $traktivity_event['show_link'] ) {
+		$traktivity_parts[] = sprintf(
+			'<span class="traktivity-event-title__show"><a href="%1$s">%2$s</a></span>',
+			esc_url( $traktivity_event['show_link'] ),
+			esc_html( $traktivity_event['show_name'] )
+		);
+	} else {
+		$traktivity_parts[] = sprintf(
+			'<span class="traktivity-event-title__show">%s</span>',
+			esc_html( $traktivity_event['show_name'] )
+		);
+	}
+}
+
+if ( '' !== $traktivity_event['episode_code'] ) {
+	$traktivity_parts[] = sprintf(
+		'<span class="traktivity-event-title__code">%s</span>',
+		esc_html( $traktivity_event['episode_code'] )
+	);
+}
+
+$traktivity_name = esc_html( $traktivity_event['title'] );
+
+if ( ! empty( $attributes['isLink'] ) && '' !== $traktivity_event['permalink'] ) {
+	$traktivity_name = sprintf(
+		'<a href="%1$s">%2$s</a>',
+		esc_url( $traktivity_event['permalink'] ),
+		$traktivity_name
+	);
+}
+
+$traktivity_parts[] = sprintf( '<span class="traktivity-event-title__name">%s</span>', $traktivity_name );
+?>
+<<?php echo esc_html( $traktivity_tag ); ?> <?php echo $traktivity_wrapper; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Prepared by get_block_wrapper_attributes(). ?>>
+	<?php echo implode( ' ', $traktivity_parts ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Each part is escaped as it is built above. ?>
+</<?php echo esc_html( $traktivity_tag ); ?>>

--- a/src/blocks/event-title/style.scss
+++ b/src/blocks/event-title/style.scss
@@ -1,0 +1,15 @@
+/**
+ * Event Title.
+ *
+ * Each part is wrapped so a theme can style the show name and the episode code
+ * separately from the episode name, which most designs want to do.
+ */
+
+.traktivity-event-title__show,
+.traktivity-event-title__code {
+	opacity: 0.7;
+}
+
+.traktivity-event-title__code {
+	white-space: nowrap;
+}

--- a/tests/package/verify-package.mjs
+++ b/tests/package/verify-package.mjs
@@ -104,6 +104,8 @@ for ( const required of [
 	'build/blocks/event-card/block.json',
 	'build/blocks/event-card/render.php',
 	'build/blocks/event-card/style-index.css',
+	'build/blocks/event-title/block.json',
+	'build/blocks/event-title/render.php',
 ] ) {
 	check( has( required ), `ships ${ required }` );
 }

--- a/tests/php/EventTitleBlockTest.php
+++ b/tests/php/EventTitleBlockTest.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * Tests for the Event Title block.
+ *
+ * @package Traktivity
+ */
+
+/**
+ * Rendering a heading that identifies what was watched.
+ */
+class EventTitleBlockTest extends WP_UnitTestCase {
+
+	/**
+	 * Register the block from its built directory, if there is one.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$built = TRAKTIVITY__PLUGIN_DIR . 'build/blocks/event-title';
+
+		if ( ! WP_Block_Type_Registry::get_instance()->is_registered( 'traktivity/event-title' ) && is_dir( $built ) ) {
+			register_block_type( $built );
+		}
+	}
+
+	/**
+	 * Build an event the way the sync would.
+	 *
+	 * @param array  $meta       Post meta.
+	 * @param array  $taxonomies Terms, keyed by taxonomy.
+	 * @param string $title      Post title.
+	 *
+	 * @return int Post ID.
+	 */
+	private function make_event( array $meta, array $taxonomies = array(), $title = 'Episode Name' ) {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'  => 'traktivity_event',
+				'post_title' => $title,
+			)
+		);
+
+		foreach ( $meta as $key => $value ) {
+			update_post_meta( $post_id, $key, $value );
+		}
+
+		// Always an array: a bare "0" reads as empty to wp_set_object_terms(). See #702.
+		foreach ( $taxonomies as $taxonomy => $terms ) {
+			wp_set_object_terms( $post_id, (array) $terms, $taxonomy );
+		}
+
+		return $post_id;
+	}
+
+	/**
+	 * Render the title against a post.
+	 *
+	 * @param int   $post_id Post to render against.
+	 * @param array $attrs   Block attributes.
+	 *
+	 * @return string Rendered HTML.
+	 */
+	private function render( $post_id, array $attrs = array() ) {
+		$previous        = isset( $GLOBALS['post'] ) ? $GLOBALS['post'] : null;
+		$GLOBALS['post'] = get_post( $post_id );
+
+		$html = render_block(
+			array(
+				'blockName'    => 'traktivity/event-title',
+				'attrs'        => $attrs,
+				'innerHTML'    => '',
+				'innerBlocks'  => array(),
+				'innerContent' => array(),
+			)
+		);
+
+		$GLOBALS['post'] = $previous;
+
+		return $html;
+	}
+
+	/**
+	 * Build a full TV event.
+	 *
+	 * @return int Post ID.
+	 */
+	private function make_tv_event() {
+		return $this->make_event(
+			array( 'trakt_show_id' => 1 ),
+			array(
+				'trakt_show'    => 'Some Show',
+				'trakt_season'  => '3',
+				'trakt_episode' => '2',
+			)
+		);
+	}
+
+	/**
+	 * A TV episode is identified in full.
+	 */
+	public function test_tv_title() {
+		$html = $this->render( $this->make_tv_event() );
+
+		$this->assertStringContainsString( 'Some Show', $html );
+		$this->assertStringContainsString( 'S3E2', $html );
+		$this->assertStringContainsString( 'Episode Name', $html );
+		$this->assertStringContainsString( '<h1', $html );
+	}
+
+	/**
+	 * The show name links to its archive by default.
+	 */
+	public function test_show_name_is_linked() {
+		$this->assertStringContainsString( '<a href', $this->render( $this->make_tv_event() ) );
+	}
+
+	/**
+	 * The show name link can be turned off without dropping the name.
+	 */
+	public function test_show_name_link_can_be_dropped() {
+		$html = $this->render( $this->make_tv_event(), array( 'linkShowName' => false ) );
+
+		$this->assertStringContainsString( 'Some Show', $html );
+		$this->assertStringNotContainsString( '<a href', $html );
+	}
+
+	/**
+	 * The show name can be dropped entirely.
+	 */
+	public function test_show_name_can_be_dropped() {
+		$html = $this->render( $this->make_tv_event(), array( 'showShowName' => false ) );
+
+		$this->assertStringNotContainsString( 'Some Show', $html );
+		$this->assertStringContainsString( 'S3E2', $html );
+	}
+
+	/**
+	 * A movie gets its plain title, with no leftover markup.
+	 */
+	public function test_movie_title() {
+		$post_id = $this->make_event( array( 'trakt_movie_id' => 2 ), array(), 'A Film' );
+
+		$html = $this->render( $post_id );
+
+		$this->assertStringContainsString( 'A Film', $html );
+		$this->assertStringNotContainsString( 'traktivity-event-title__code', $html );
+		$this->assertStringNotContainsString( 'traktivity-event-title__show', $html );
+	}
+
+	/**
+	 * The heading level is configurable and clamped.
+	 */
+	public function test_heading_level() {
+		$post_id = $this->make_tv_event();
+
+		$this->assertStringContainsString( '<h3', $this->render( $post_id, array( 'level' => 3 ) ) );
+		$this->assertStringContainsString( '<h6', $this->render( $post_id, array( 'level' => 42 ) ) );
+	}
+
+	/**
+	 * The title can link to the entry, for a listing.
+	 */
+	public function test_title_can_link_to_the_entry() {
+		$post_id = $this->make_event( array( 'trakt_movie_id' => 3 ), array(), 'A Film' );
+
+		$html = $this->render( $post_id, array( 'isLink' => true ) );
+
+		$this->assertStringContainsString( get_permalink( $post_id ), $html );
+	}
+
+	/**
+	 * An episode missing its numbers still names the show.
+	 */
+	public function test_partial_data_still_identifies_something() {
+		$post_id = $this->make_event(
+			array( 'trakt_show_id' => 4 ),
+			array( 'trakt_show' => 'Some Show' )
+		);
+
+		$html = $this->render( $post_id );
+
+		$this->assertStringContainsString( 'Some Show', $html );
+		$this->assertStringNotContainsString( 'traktivity-event-title__code', $html );
+	}
+
+	/**
+	 * A post that is not an event renders nothing.
+	 */
+	public function test_other_post_types_render_nothing() {
+		$this->assertSame( '', trim( $this->render( self::factory()->post->create() ) ) );
+	}
+}


### PR DESCRIPTION
Fixes #691

## What it does

A drop-in replacement for core's Post Title on a `traktivity_event`, printing a
heading that identifies what was watched:

```html
<h1 class="traktivity-event-title wp-block-traktivity-event-title">
	<span class="traktivity-event-title__show"><a href="…">Some Show</a></span>
	<span class="traktivity-event-title__code">S3E2</span>
	<span class="traktivity-event-title__name">Episode Name</span>
</h1>
```

Attributes: heading level, whether the series name appears, whether it links, and
whether the title itself links to the entry.

## Rationale

Core's Post Title prints the bare episode name. On a single event template that
leaves you with a page whose `<h1>` says nothing about which series it belongs to
or where in the run it sits, and both facts live in taxonomies the title knows
nothing about.

**The parts are assembled here rather than through
`traktivity_get_event_title()`.** That helper returns plain text by design, and a
linked series name needs markup. Building it from the separate `show_name` and
`show_link` keys keeps each part escapable on its own, instead of putting the
escaping rule behind an argument — the thing #685 deliberately avoided.

**Each part gets its own wrapper element**, because most designs want the series
name and the episode code in a different weight or colour from the episode name,
and a theme can't target what isn't marked up.

Movies get their plain title with no empty wrappers left behind. An episode
missing its season or episode terms still names its series rather than falling
back to the bare name.

## Usage

```html
<!-- wp:traktivity/event-title {"level":1} /-->

<!-- In a listing, where the series is already named above: -->
<!-- wp:traktivity/event-title {"level":3,"showShowName":false,"isLink":true} /-->
```

## Testing

`composer run lint && composer run analyse` clean. PHPUnit 163 passing, 349
assertions. Build, package check and the JS gates all pass.

New coverage: a full TV title, the series name linked, the link dropped without
losing the name, the series name dropped entirely, a movie leaving no empty
wrappers, the heading level configurable and clamped, the title linking to the
entry, partial data still identifying the series, and a post of the wrong type
rendering nothing.
