### PR TITLE
Add an Event Details block, so a single entry is worth visiting

### DIFF
--- a/src/blocks/event-details/block.json
+++ b/src/blocks/event-details/block.json
@@ -1,0 +1,30 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "traktivity/event-details",
+	"title": "Event Details",
+	"category": "traktivity",
+	"icon": "info-outline",
+	"description": "Series, season, genre, runtime and external links for one watch event.",
+	"textdomain": "traktivity",
+	"usesContext": [ "postId", "postType" ],
+	"attributes": {
+		"showTaxonomies": { "type": "boolean", "default": true },
+		"showRuntime": { "type": "boolean", "default": true },
+		"showLinks": { "type": "boolean", "default": true }
+	},
+	"supports": {
+		"html": false,
+		"reusable": false,
+		"color": {
+			"background": true,
+			"text": true,
+			"link": true
+		},
+		"spacing": { "margin": true, "padding": true },
+		"typography": { "fontSize": true, "lineHeight": true }
+	},
+	"editorScript": "file:./index.js",
+	"style": [ "traktivity-shared", "file:./style-index.css" ],
+	"render": "file:./render.php"
+}

--- a/src/blocks/event-details/index.js
+++ b/src/blocks/event-details/index.js
@@ -1,0 +1,76 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, ToggleControl } from '@wordpress/components';
+import ServerSideRender from '@wordpress/server-side-render';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import './style.scss';
+
+/**
+ * Preview the details table.
+ *
+ * @param {Object}   props               Block props.
+ * @param {Object}   props.attributes    Block attributes.
+ * @param {Function} props.setAttributes Attribute setter.
+ * @param {Object}   props.context       Block context, carrying the post ID.
+ * @return {Element} The editor preview.
+ */
+function Edit( { attributes, setAttributes, context } ) {
+	const blockProps = useBlockProps();
+
+	return (
+		<div { ...blockProps }>
+			<InspectorControls>
+				<PanelBody title={ __( 'Rows', 'traktivity' ) }>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __(
+							'Series, season, genre and year',
+							'traktivity'
+						) }
+						checked={ attributes.showTaxonomies }
+						onChange={ ( showTaxonomies ) =>
+							setAttributes( { showTaxonomies } )
+						}
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Runtime', 'traktivity' ) }
+						checked={ attributes.showRuntime }
+						onChange={ ( showRuntime ) =>
+							setAttributes( { showRuntime } )
+						}
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __(
+							'Links to Trakt.tv, IMDb and TMDb',
+							'traktivity'
+						) }
+						checked={ attributes.showLinks }
+						onChange={ ( showLinks ) =>
+							setAttributes( { showLinks } )
+						}
+					/>
+				</PanelBody>
+			</InspectorControls>
+
+			<ServerSideRender
+				block={ metadata.name }
+				attributes={ attributes }
+				urlQueryArgs={
+					context?.postId ? { post_id: context.postId } : {}
+				}
+			/>
+		</div>
+	);
+}
+
+registerBlockType( metadata.name, { edit: Edit } );

--- a/src/blocks/event-details/render.php
+++ b/src/blocks/event-details/render.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Render the Event Details block.
+ *
+ * @package Traktivity
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block default content.
+ * @var WP_Block $block      Block instance.
+ */
+
+declare( strict_types = 1 );
+
+defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
+
+$traktivity_post_id = isset( $block->context['postId'] ) ? (int) $block->context['postId'] : (int) get_the_ID();
+
+if ( $traktivity_post_id < 1 ) {
+	return;
+}
+
+$traktivity_event = traktivity_get_event( $traktivity_post_id );
+
+if ( '' === $traktivity_event['type'] ) {
+	return;
+}
+
+/*
+ * Rows are built as label => value pairs. Most values are escaped as they are
+ * added; the two taxonomy lists arrive from get_the_term_list() as markup and
+ * go through wp_kses_post() instead. Nothing is escaped again at output, so a
+ * new row has to escape itself here.
+ */
+$traktivity_rows = array();
+
+if ( ! isset( $attributes['showTaxonomies'] ) || $attributes['showTaxonomies'] ) {
+	if ( '' !== $traktivity_event['show_name'] ) {
+		$traktivity_rows[ __( 'Series', 'traktivity' ) ] = '' !== $traktivity_event['show_link']
+			? sprintf( '<a href="%1$s">%2$s</a>', esc_url( $traktivity_event['show_link'] ), esc_html( $traktivity_event['show_name'] ) )
+			: esc_html( $traktivity_event['show_name'] );
+	}
+
+	if ( '' !== $traktivity_event['episode_code'] ) {
+		$traktivity_rows[ __( 'Season', 'traktivity' ) ]  = esc_html( number_format_i18n( $traktivity_event['season'] ) );
+		$traktivity_rows[ __( 'Episode', 'traktivity' ) ] = esc_html( number_format_i18n( $traktivity_event['episode'] ) );
+	}
+
+	$traktivity_genres = get_the_term_list( $traktivity_post_id, 'trakt_genre', '', ', ' );
+	if ( ! is_wp_error( $traktivity_genres ) && ! empty( $traktivity_genres ) ) {
+		$traktivity_rows[ __( 'Genre', 'traktivity' ) ] = wp_kses_post( $traktivity_genres );
+	}
+
+	$traktivity_years = get_the_term_list( $traktivity_post_id, 'trakt_year', '', ', ' );
+	if ( ! is_wp_error( $traktivity_years ) && ! empty( $traktivity_years ) ) {
+		$traktivity_rows[ __( 'Released', 'traktivity' ) ] = wp_kses_post( $traktivity_years );
+	}
+}
+
+if ( ( ! isset( $attributes['showRuntime'] ) || $attributes['showRuntime'] ) && $traktivity_event['runtime'] > 0 ) {
+	$traktivity_rows[ __( 'Runtime', 'traktivity' ) ] = esc_html(
+		sprintf(
+			/* translators: %s: number of minutes. */
+			_n( '%s minute', '%s minutes', $traktivity_event['runtime'], 'traktivity' ),
+			number_format_i18n( $traktivity_event['runtime'] )
+		)
+	);
+}
+
+if ( ! isset( $attributes['showLinks'] ) || $attributes['showLinks'] ) {
+	$traktivity_links = array();
+
+	foreach ( traktivity_get_event_links( $traktivity_post_id ) as $traktivity_link ) {
+		$traktivity_links[] = sprintf(
+			'<a href="%1$s">%2$s</a>',
+			esc_url( $traktivity_link['url'] ),
+			esc_html( $traktivity_link['label'] )
+		);
+	}
+
+	if ( ! empty( $traktivity_links ) ) {
+		$traktivity_rows[ __( 'Look up', 'traktivity' ) ] = implode(
+			' <span class="traktivity-sep" aria-hidden="true">&middot;</span> ',
+			$traktivity_links
+		);
+	}
+}
+
+if ( empty( $traktivity_rows ) ) {
+	return;
+}
+
+$traktivity_wrapper = get_block_wrapper_attributes( array( 'class' => 'traktivity-details' ) );
+?>
+<dl <?php echo $traktivity_wrapper; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Prepared by get_block_wrapper_attributes(). ?>>
+	<?php foreach ( $traktivity_rows as $traktivity_label => $traktivity_value ) : ?>
+		<div class="traktivity-details__row">
+			<dt><?php echo esc_html( $traktivity_label ); ?></dt>
+			<dd><?php echo $traktivity_value; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Each value is escaped as it is built above. ?></dd>
+		</div>
+	<?php endforeach; ?>
+</dl>

--- a/src/blocks/event-details/style.scss
+++ b/src/blocks/event-details/style.scss
@@ -1,0 +1,36 @@
+/**
+ * Event Details.
+ *
+ * A definition list, so the label and value pairing is in the markup rather
+ * than only in the styling. The grid is what makes it read as a table.
+ */
+
+.traktivity-details {
+	display: grid;
+	gap: 0.5em 1.5em;
+	margin: 0;
+}
+
+.traktivity-details__row {
+	display: grid;
+	gap: 0.25em 1.5em;
+	grid-template-columns: minmax(6em, 10em) 1fr;
+}
+
+.traktivity-details dt {
+	font-size: var(--wp--preset--font-size--small, 0.8125rem);
+	letter-spacing: 0.06em;
+	opacity: 0.7;
+	text-transform: uppercase;
+}
+
+.traktivity-details dd {
+	margin: 0;
+}
+
+@media (max-width: 480px) {
+
+	.traktivity-details__row {
+		grid-template-columns: 1fr;
+	}
+}

--- a/tests/package/verify-package.mjs
+++ b/tests/package/verify-package.mjs
@@ -106,6 +106,8 @@ for ( const required of [
 	'build/blocks/event-card/style-index.css',
 	'build/blocks/event-title/block.json',
 	'build/blocks/event-title/render.php',
+	'build/blocks/event-details/block.json',
+	'build/blocks/event-details/render.php',
 ] ) {
 	check( has( required ), `ships ${ required }` );
 }

--- a/tests/php/EventDetailsBlockTest.php
+++ b/tests/php/EventDetailsBlockTest.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Tests for the Event Details block.
+ *
+ * @package Traktivity
+ */
+
+/**
+ * Rendering the detail rows for one watch event.
+ */
+class EventDetailsBlockTest extends WP_UnitTestCase {
+
+	/**
+	 * Register the block from its built directory, if there is one.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$built = TRAKTIVITY__PLUGIN_DIR . 'build/blocks/event-details';
+
+		if ( ! WP_Block_Type_Registry::get_instance()->is_registered( 'traktivity/event-details' ) && is_dir( $built ) ) {
+			register_block_type( $built );
+		}
+	}
+
+	/**
+	 * Build an event the way the sync would.
+	 *
+	 * @param array $meta       Post meta.
+	 * @param array $taxonomies Terms, keyed by taxonomy.
+	 *
+	 * @return int Post ID.
+	 */
+	private function make_event( array $meta, array $taxonomies = array() ) {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'  => 'traktivity_event',
+				'post_title' => 'Episode Name',
+			)
+		);
+
+		foreach ( $meta as $key => $value ) {
+			update_post_meta( $post_id, $key, $value );
+		}
+
+		// Always an array: a bare "0" reads as empty to wp_set_object_terms(). See #702.
+		foreach ( $taxonomies as $taxonomy => $terms ) {
+			wp_set_object_terms( $post_id, (array) $terms, $taxonomy );
+		}
+
+		return $post_id;
+	}
+
+	/**
+	 * Render the details against a post.
+	 *
+	 * @param int   $post_id Post to render against.
+	 * @param array $attrs   Block attributes.
+	 *
+	 * @return string Rendered HTML.
+	 */
+	private function render( $post_id, array $attrs = array() ) {
+		$previous        = isset( $GLOBALS['post'] ) ? $GLOBALS['post'] : null;
+		$GLOBALS['post'] = get_post( $post_id );
+
+		$html = render_block(
+			array(
+				'blockName'    => 'traktivity/event-details',
+				'attrs'        => $attrs,
+				'innerHTML'    => '',
+				'innerBlocks'  => array(),
+				'innerContent' => array(),
+			)
+		);
+
+		$GLOBALS['post'] = $previous;
+
+		return $html;
+	}
+
+	/**
+	 * A full TV event gets every row.
+	 */
+	public function test_tv_event_rows() {
+		$post_id = $this->make_event(
+			array(
+				'trakt_show_id'   => 1,
+				'trakt_runtime'   => 60,
+				'imdb_episode_id' => 'tt1234567',
+			),
+			array(
+				'trakt_show'    => 'Some Show',
+				'trakt_season'  => '3',
+				'trakt_episode' => '2',
+				'trakt_genre'   => 'Drama',
+				'trakt_year'    => '2023',
+			)
+		);
+
+		$html = $this->render( $post_id );
+
+		$this->assertStringContainsString( 'Series', $html );
+		$this->assertStringContainsString( 'Some Show', $html );
+		$this->assertStringContainsString( 'Season', $html );
+		$this->assertStringContainsString( 'Episode', $html );
+		$this->assertStringContainsString( 'Drama', $html );
+		$this->assertStringContainsString( '2023', $html );
+		$this->assertStringContainsString( '60 minutes', $html );
+		$this->assertStringContainsString( 'imdb.com', $html );
+		$this->assertStringContainsString( '<dl', $html );
+	}
+
+	/**
+	 * A movie gets no season or episode rows.
+	 */
+	public function test_movie_has_no_episode_rows() {
+		$post_id = $this->make_event(
+			array(
+				'trakt_movie_id' => 2,
+				'imdb_movie_id'  => 'tt7654321',
+			),
+			array( 'trakt_year' => '2019' )
+		);
+
+		$html = $this->render( $post_id );
+
+		$this->assertStringNotContainsString( 'Season', $html );
+		$this->assertStringNotContainsString( 'Series', $html );
+		$this->assertStringContainsString( 'tt7654321', $html );
+	}
+
+	/**
+	 * Rows with no data are left out rather than rendered empty.
+	 *
+	 * The Trakt row survives because trakt_show_id is what makes this a TV
+	 * event in the first place, so every episode has at least that one link.
+	 */
+	public function test_rows_without_data_are_absent() {
+		$post_id = $this->make_event( array( 'trakt_show_id' => 3 ) );
+
+		$html = $this->render( $post_id );
+
+		$this->assertStringNotContainsString( 'Runtime', $html );
+		$this->assertStringNotContainsString( 'Genre', $html );
+		$this->assertStringNotContainsString( 'Series', $html );
+		$this->assertStringContainsString( 'Look up', $html );
+	}
+
+	/**
+	 * With nothing left to say, the block renders nothing rather than an
+	 * empty definition list.
+	 */
+	public function test_block_with_no_rows_renders_nothing() {
+		$post_id = $this->make_event( array( 'trakt_show_id' => 4 ) );
+
+		$this->assertSame( '', trim( $this->render( $post_id, array( 'showLinks' => false ) ) ) );
+	}
+
+	/**
+	 * Each group of rows can be turned off.
+	 */
+	public function test_groups_can_be_hidden() {
+		$post_id = $this->make_event(
+			array(
+				'trakt_show_id'   => 5,
+				'trakt_runtime'   => 45,
+				'imdb_episode_id' => 'tt1111111',
+			),
+			array( 'trakt_show' => 'Some Show' )
+		);
+
+		$no_links = $this->render( $post_id, array( 'showLinks' => false ) );
+		$this->assertStringNotContainsString( 'imdb.com', $no_links );
+		$this->assertStringContainsString( 'Some Show', $no_links );
+
+		$no_runtime = $this->render( $post_id, array( 'showRuntime' => false ) );
+		$this->assertStringNotContainsString( 'Runtime', $no_runtime );
+
+		$no_tax = $this->render( $post_id, array( 'showTaxonomies' => false ) );
+		$this->assertStringNotContainsString( 'Some Show', $no_tax );
+		$this->assertStringContainsString( 'Runtime', $no_tax );
+	}
+
+	/**
+	 * A runtime of one minute is singular.
+	 */
+	public function test_runtime_is_pluralised() {
+		$post_id = $this->make_event(
+			array(
+				'trakt_show_id' => 6,
+				'trakt_runtime' => 1,
+			)
+		);
+
+		$this->assertStringContainsString( '1 minute<', $this->render( $post_id ) );
+	}
+
+	/**
+	 * A post that is not an event renders nothing.
+	 */
+	public function test_other_post_types_render_nothing() {
+		$this->assertSame( '', trim( $this->render( self::factory()->post->create() ) ) );
+	}
+}


### PR DESCRIPTION
Fixes #692

## What it does

The detail table for a single event: series, season, episode, genre, release
year, runtime, and links out to Trakt.tv, IMDb and TMDb. Rendered as a `<dl>`.

Three toggles group the rows: the taxonomy rows, the runtime, and the external
links.

## Rationale

A single `traktivity_event` page shows a title, a date, and whatever the sync put
in the content. Everything else the plugin knows about that event is invisible.
This is the block that makes the page worth visiting.

- **A definition list, not a table or a stack of paragraphs.** The label/value
  pairing belongs in the markup rather than only in the styling.
- **Rows with nothing to say are left out**, and with no rows left the block
  renders nothing rather than an empty `<dl>`.
- **Movies get no series or season rows**, and pick up the movie IDs for their
  links via `traktivity_get_event_links()`.
- **Escaping is deliberate and written down.** The two taxonomy rows arrive from
  `get_the_term_list()` as markup and go through `wp_kses_post()`; everything else
  is escaped as it's added. Nothing is escaped again at output, so the rule is
  stated where a new row would be added rather than left to be inferred.

## One correction while testing

My first pass asserted that a bare TV event renders no rows at all. It doesn't,
and the block is right: `trakt_show_id` is what makes an event a TV episode in
the first place, so every episode has at least a Trakt link. The test now asserts
that, and the "renders nothing" case turns the links off to get there honestly.

## Usage

```html
<!-- wp:traktivity/event-details /-->

<!-- Taxonomy rows only: -->
<!-- wp:traktivity/event-details {"showLinks":false,"showRuntime":false} /-->
```

## Testing

`composer run lint && composer run analyse` clean. PHPUnit 170 passing, 373
assertions. Build, package check and the JS gates all pass.

New coverage: a full TV event, a movie with no episode rows, rows without data
being absent, the block rendering nothing when no rows remain, each group being
hidden independently, a one-minute runtime staying singular, and a post of the
wrong type rendering nothing.
