### PR TITLE
Add a Watch Stats block for the headline totals

### DIFF
--- a/src/blocks/watch-stats/block.json
+++ b/src/blocks/watch-stats/block.json
@@ -1,0 +1,32 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "traktivity/watch-stats",
+	"title": "Watch Stats",
+	"category": "traktivity",
+	"icon": "chart-bar",
+	"description": "Headline totals for everything logged.",
+	"textdomain": "traktivity",
+	"attributes": {
+		"figures": {
+			"type": "array",
+			"default": [ "hours", "entries", "episodes", "films", "shows", "since" ],
+			"items": { "type": "string" }
+		},
+		"layout": { "type": "string", "default": "row" }
+	},
+	"supports": {
+		"html": false,
+		"reusable": false,
+		"align": [ "wide", "full" ],
+		"color": {
+			"background": true,
+			"text": true
+		},
+		"spacing": { "margin": true, "padding": true, "blockGap": true },
+		"typography": { "fontSize": true, "lineHeight": true }
+	},
+	"editorScript": "file:./index.js",
+	"style": [ "traktivity-shared", "file:./style-index.css" ],
+	"render": "file:./render.php"
+}

--- a/src/blocks/watch-stats/index.js
+++ b/src/blocks/watch-stats/index.js
@@ -1,0 +1,108 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	Button,
+	CheckboxControl,
+	PanelBody,
+	SelectControl,
+} from '@wordpress/components';
+import ServerSideRender from '@wordpress/server-side-render';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import './style.scss';
+
+const FIGURES = [
+	{ key: 'hours', label: __( 'Hours watched', 'traktivity' ) },
+	{ key: 'entries', label: __( 'Entries logged', 'traktivity' ) },
+	{ key: 'episodes', label: __( 'Episodes', 'traktivity' ) },
+	{ key: 'films', label: __( 'Films', 'traktivity' ) },
+	{ key: 'shows', label: __( 'Series', 'traktivity' ) },
+	{ key: 'since', label: __( 'Logging since', 'traktivity' ) },
+];
+
+/**
+ * Pick which figures to show, and in what order.
+ *
+ * Order is the order they were ticked, so a checkbox list doubles as the
+ * ordering control and there is no separate drag handle to build.
+ *
+ * @param {Object}   props               Block props.
+ * @param {Object}   props.attributes    Block attributes.
+ * @param {Function} props.setAttributes Attribute setter.
+ * @return {Element} The editor preview.
+ */
+function Edit( { attributes, setAttributes } ) {
+	const blockProps = useBlockProps();
+	const chosen = attributes.figures || [];
+
+	const toggle = ( key ) => {
+		setAttributes( {
+			figures: chosen.includes( key )
+				? chosen.filter( ( item ) => item !== key )
+				: [ ...chosen, key ],
+		} );
+	};
+
+	return (
+		<div { ...blockProps }>
+			<InspectorControls>
+				<PanelBody title={ __( 'Figures', 'traktivity' ) }>
+					{ FIGURES.map( ( { key, label } ) => (
+						<CheckboxControl
+							__nextHasNoMarginBottom
+							key={ key }
+							label={ label }
+							checked={ chosen.includes( key ) }
+							onChange={ () => toggle( key ) }
+						/>
+					) ) }
+					<Button
+						variant="secondary"
+						onClick={ () =>
+							setAttributes( {
+								figures: FIGURES.map(
+									( figure ) => figure.key
+								),
+							} )
+						}
+					>
+						{ __( 'Show all', 'traktivity' ) }
+					</Button>
+				</PanelBody>
+				<PanelBody title={ __( 'Layout', 'traktivity' ) }>
+					<SelectControl
+						__nextHasNoMarginBottom
+						label={ __( 'Arrangement', 'traktivity' ) }
+						help={ __(
+							'A stack suits a sidebar; a row suits a full-width band.',
+							'traktivity'
+						) }
+						value={ attributes.layout }
+						options={ [
+							{ label: __( 'Row', 'traktivity' ), value: 'row' },
+							{
+								label: __( 'Stack', 'traktivity' ),
+								value: 'stack',
+							},
+						] }
+						onChange={ ( layout ) => setAttributes( { layout } ) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+
+			<ServerSideRender
+				block={ metadata.name }
+				attributes={ attributes }
+			/>
+		</div>
+	);
+}
+
+registerBlockType( metadata.name, { edit: Edit } );

--- a/src/blocks/watch-stats/render.php
+++ b/src/blocks/watch-stats/render.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Render the Watch Stats block.
+ *
+ * @package Traktivity
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block default content.
+ * @var WP_Block $block      Block instance.
+ */
+
+declare( strict_types = 1 );
+
+defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
+
+$traktivity_stats = Traktivity_Stats::get_summary();
+
+/*
+ * A site that has not synced yet would otherwise show a row of zeroes, which
+ * reads as broken rather than as empty. Nothing logged, nothing rendered.
+ */
+if ( $traktivity_stats['entries'] < 1 ) {
+	return;
+}
+
+$traktivity_available = array(
+	'hours'    => array(
+		'value' => number_format_i18n( $traktivity_stats['hours'] ),
+		'label' => _n( 'Hour', 'Hours', $traktivity_stats['hours'], 'traktivity' ),
+	),
+	'entries'  => array(
+		'value' => number_format_i18n( $traktivity_stats['entries'] ),
+		'label' => _n( 'Entry', 'Entries', $traktivity_stats['entries'], 'traktivity' ),
+	),
+	'episodes' => array(
+		'value' => number_format_i18n( $traktivity_stats['episodes'] ),
+		'label' => _n( 'Episode', 'Episodes', $traktivity_stats['episodes'], 'traktivity' ),
+	),
+	'films'    => array(
+		'value' => number_format_i18n( $traktivity_stats['films'] ),
+		'label' => _n( 'Film', 'Films', $traktivity_stats['films'], 'traktivity' ),
+	),
+	'shows'    => array(
+		'value' => number_format_i18n( $traktivity_stats['shows'] ),
+		'label' => _n( 'Series', 'Series', $traktivity_stats['shows'], 'traktivity' ),
+	),
+);
+
+if ( '' !== $traktivity_stats['since'] ) {
+	$traktivity_available['since'] = array(
+		'value' => $traktivity_stats['since'],
+		'label' => __( 'Logging since', 'traktivity' ),
+	);
+}
+
+$traktivity_chosen = isset( $attributes['figures'] ) && is_array( $attributes['figures'] )
+	? $attributes['figures']
+	: array_keys( $traktivity_available );
+
+$traktivity_cells = array();
+
+foreach ( $traktivity_chosen as $traktivity_key ) {
+	if ( isset( $traktivity_available[ $traktivity_key ] ) ) {
+		$traktivity_cells[] = $traktivity_available[ $traktivity_key ];
+	}
+}
+
+if ( empty( $traktivity_cells ) ) {
+	return;
+}
+
+$traktivity_layout  = isset( $attributes['layout'] ) && 'stack' === $attributes['layout'] ? 'stack' : 'row';
+$traktivity_wrapper = get_block_wrapper_attributes(
+	array( 'class' => 'traktivity-stats traktivity-stats--' . $traktivity_layout )
+);
+?>
+<div <?php echo $traktivity_wrapper; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Prepared by get_block_wrapper_attributes(). ?>>
+	<?php foreach ( $traktivity_cells as $traktivity_cell ) : ?>
+		<div class="traktivity-stats__cell">
+			<span class="traktivity-stats__value"><?php echo esc_html( $traktivity_cell['value'] ); ?></span>
+			<span class="traktivity-stats__label"><?php echo esc_html( $traktivity_cell['label'] ); ?></span>
+		</div>
+	<?php endforeach; ?>
+</div>

--- a/src/blocks/watch-stats/style.scss
+++ b/src/blocks/watch-stats/style.scss
@@ -1,0 +1,48 @@
+/**
+ * Watch Stats.
+ *
+ * Two layouts, because this has to work as a full-width band on a homepage and
+ * as a narrow list in a sidebar.
+ */
+
+.traktivity-stats {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--wp--style--block-gap, 1.5em);
+}
+
+.traktivity-stats--row {
+	flex-direction: row;
+}
+
+.traktivity-stats--stack {
+	flex-direction: column;
+}
+
+.traktivity-stats__cell {
+	display: flex;
+	flex-direction: column;
+}
+
+.traktivity-stats--row .traktivity-stats__cell {
+	flex: 1 1 auto;
+}
+
+.traktivity-stats--stack .traktivity-stats__cell {
+	align-items: baseline;
+	flex-direction: row;
+	gap: 0.5em;
+	justify-content: space-between;
+}
+
+.traktivity-stats__value {
+	font-size: var(--wp--preset--font-size--x-large, 2rem);
+	line-height: 1.1;
+}
+
+.traktivity-stats__label {
+	font-size: var(--wp--preset--font-size--small, 0.8125rem);
+	letter-spacing: 0.08em;
+	opacity: 0.7;
+	text-transform: uppercase;
+}

--- a/tests/package/verify-package.mjs
+++ b/tests/package/verify-package.mjs
@@ -108,6 +108,8 @@ for ( const required of [
 	'build/blocks/event-title/render.php',
 	'build/blocks/event-details/block.json',
 	'build/blocks/event-details/render.php',
+	'build/blocks/watch-stats/block.json',
+	'build/blocks/watch-stats/render.php',
 ] ) {
 	check( has( required ), `ships ${ required }` );
 }

--- a/tests/php/WatchStatsBlockTest.php
+++ b/tests/php/WatchStatsBlockTest.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Tests for the Watch Stats block.
+ *
+ * @package Traktivity
+ */
+
+/**
+ * Rendering the headline figures.
+ */
+class WatchStatsBlockTest extends WP_UnitTestCase {
+
+	/**
+	 * Register the block and start from a cold stats cache.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$built = TRAKTIVITY__PLUGIN_DIR . 'build/blocks/watch-stats';
+
+		if ( ! WP_Block_Type_Registry::get_instance()->is_registered( 'traktivity/watch-stats' ) && is_dir( $built ) ) {
+			register_block_type( $built );
+		}
+
+		Traktivity_Stats::reset_flush_guard();
+		Traktivity_Stats::flush( true );
+	}
+
+	/**
+	 * Create a published event.
+	 *
+	 * @param string $id_key  Either trakt_show_id or trakt_movie_id.
+	 * @param int    $runtime Minutes.
+	 *
+	 * @return int Post ID.
+	 */
+	private function make_event( $id_key, $runtime = 60 ) {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'traktivity_event',
+				'post_status' => 'publish',
+			)
+		);
+
+		update_post_meta( $post_id, $id_key, 1 );
+		update_post_meta( $post_id, 'trakt_runtime', $runtime );
+
+		return $post_id;
+	}
+
+	/**
+	 * Render the block.
+	 *
+	 * @param array $attrs Block attributes.
+	 *
+	 * @return string Rendered HTML.
+	 */
+	private function render( array $attrs = array() ) {
+		return render_block(
+			array(
+				'blockName'    => 'traktivity/watch-stats',
+				'attrs'        => $attrs,
+				'innerHTML'    => '',
+				'innerBlocks'  => array(),
+				'innerContent' => array(),
+			)
+		);
+	}
+
+	/**
+	 * A site with nothing logged renders nothing.
+	 *
+	 * A row of zeroes reads as broken rather than as empty, which is the
+	 * wrong first impression for someone who has just activated the plugin.
+	 */
+	public function test_empty_site_renders_nothing() {
+		$this->assertSame( '', trim( $this->render() ) );
+	}
+
+	/**
+	 * The figures are rendered once there is something to count.
+	 */
+	public function test_figures_are_rendered() {
+		// Two of each, so every label lands on its plural form.
+		$this->make_event( 'trakt_show_id', 120 );
+		$this->make_event( 'trakt_show_id', 120 );
+		$this->make_event( 'trakt_movie_id', 120 );
+		$this->make_event( 'trakt_movie_id', 120 );
+		Traktivity_Stats::flush( true );
+
+		$html = $this->render();
+
+		$this->assertStringContainsString( 'traktivity-stats', $html );
+		$this->assertStringContainsString( 'Entries', $html );
+		$this->assertStringContainsString( 'Episodes', $html );
+		$this->assertStringContainsString( 'Films', $html );
+		$this->assertStringContainsString( 'Logging since', $html );
+	}
+
+	/**
+	 * Only the chosen figures appear, in the order they were chosen.
+	 */
+	public function test_figures_can_be_chosen_and_ordered() {
+		$this->make_event( 'trakt_show_id' );
+		$this->make_event( 'trakt_show_id' );
+		Traktivity_Stats::flush( true );
+
+		$html = $this->render( array( 'figures' => array( 'films', 'entries' ) ) );
+
+		$this->assertStringNotContainsString( 'Episodes', $html );
+		$this->assertLessThan(
+			strpos( $html, 'Entries' ),
+			strpos( $html, 'Films' ),
+			'Figures follow the order they were chosen in.'
+		);
+	}
+
+	/**
+	 * An unknown figure name is ignored rather than rendered empty.
+	 */
+	public function test_unknown_figures_are_ignored() {
+		$this->make_event( 'trakt_show_id' );
+		Traktivity_Stats::flush( true );
+
+		$html = $this->render( array( 'figures' => array( 'entries', 'nonsense' ) ) );
+
+		$this->assertStringContainsString( 'Entry', $html );
+		$this->assertStringNotContainsString( 'nonsense', $html );
+		$this->assertSame( 1, substr_count( $html, 'traktivity-stats__cell' ) );
+	}
+
+	/**
+	 * Choosing no figures renders nothing, not an empty band.
+	 */
+	public function test_no_figures_renders_nothing() {
+		$this->make_event( 'trakt_show_id' );
+		Traktivity_Stats::flush( true );
+
+		$this->assertSame( '', trim( $this->render( array( 'figures' => array() ) ) ) );
+	}
+
+	/**
+	 * The layout attribute reaches the markup.
+	 */
+	public function test_layout() {
+		$this->make_event( 'trakt_show_id' );
+		Traktivity_Stats::flush( true );
+
+		$this->assertStringContainsString( 'traktivity-stats--stack', $this->render( array( 'layout' => 'stack' ) ) );
+		$this->assertStringContainsString( 'traktivity-stats--row', $this->render( array( 'layout' => 'row' ) ) );
+	}
+
+	/**
+	 * Labels are singular where the count is one.
+	 */
+	public function test_labels_are_pluralised() {
+		$this->make_event( 'trakt_show_id' );
+		Traktivity_Stats::flush( true );
+
+		$html = $this->render( array( 'figures' => array( 'entries' ) ) );
+
+		$this->assertStringContainsString( 'Entry', $html );
+		$this->assertStringNotContainsString( 'Entries', $html );
+	}
+}


### PR DESCRIPTION
Fixes #693

## What it does

The headline totals as a row of value/label pairs: hours watched, entries
logged, episodes, films, series, and how long the logging has been going on.

Which figures appear and in what order is one array attribute. Two layouts, row
or stack.

## Rationale

None of this can be built from core blocks. Every figure needs an aggregate
query, and a Query Loop counts nothing.

- **An empty site renders nothing.** A row of zeroes reads as broken rather than
  as empty, which is the wrong first impression for someone who has just
  activated the plugin. Picking no figures does the same, rather than leaving an
  empty band behind.
- **Order comes from the array**, so the checkbox list in the editor doubles as
  the ordering control and there's no drag handle to build.
- **An unrecognised figure name is skipped**, so a stale attribute from a future
  version can't leave a blank cell in the row.
- **Two layouts**, because this has to work as a full-width band on a homepage
  and as a narrow list in a sidebar.
- Every number goes through `number_format_i18n()` and every label through
  `_n()`: with one entry logged the label reads "Entry", not "Entries".

The whole block costs one transient read rather than six queries, since the
figures come from the summary cached by #688.

## One thing my first pass got wrong

Three tests failed because I'd written the plural label everywhere and the block
was correctly rendering singulars for counts of one. The block was right; the
fixtures now create enough events for each label to land where the test expects,
and one test asserts the singular deliberately.

## Usage

```html
<!-- wp:traktivity/watch-stats {"align":"wide"} /-->

<!-- Three figures, stacked, for a sidebar: -->
<!-- wp:traktivity/watch-stats {"figures":["hours","shows","since"],"layout":"stack"} /-->
```

## Testing

`composer run lint && composer run analyse` clean. PHPUnit 177 passing, 389
assertions. Build, package check and the JS gates all pass.

New coverage: an empty site rendering nothing, the figures rendering, figures
chosen and ordered, unknown figures ignored without leaving a cell behind, no
figures rendering nothing, both layouts reaching the markup, and labels
pluralising.
