### PR TITLE
Add a Top Series block, which a Query Loop cannot express

### DIFF
--- a/src/blocks/top-shows/block.json
+++ b/src/blocks/top-shows/block.json
@@ -1,0 +1,34 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "traktivity/top-shows",
+	"title": "Top Series",
+	"category": "traktivity",
+	"icon": "grid-view",
+	"description": "Series ordered by how many episodes have been logged.",
+	"textdomain": "traktivity",
+	"attributes": {
+		"number": { "type": "number", "default": 12 },
+		"columns": { "type": "number", "default": 4 },
+		"orderby": { "type": "string", "default": "count" },
+		"showImage": { "type": "boolean", "default": true },
+		"showCount": { "type": "boolean", "default": true },
+		"showNetwork": { "type": "boolean", "default": true },
+		"headingLevel": { "type": "number", "default": 3 }
+	},
+	"supports": {
+		"html": false,
+		"reusable": false,
+		"align": [ "wide", "full" ],
+		"color": {
+			"background": true,
+			"text": true,
+			"link": true
+		},
+		"spacing": { "margin": true, "padding": true, "blockGap": true },
+		"typography": { "fontSize": true, "lineHeight": true }
+	},
+	"editorScript": "file:./index.js",
+	"style": [ "traktivity-shared", "file:./style-index.css" ],
+	"render": "file:./render.php"
+}

--- a/src/blocks/top-shows/index.js
+++ b/src/blocks/top-shows/index.js
@@ -1,0 +1,119 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	PanelBody,
+	RangeControl,
+	SelectControl,
+	ToggleControl,
+} from '@wordpress/components';
+import ServerSideRender from '@wordpress/server-side-render';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import './style.scss';
+
+/**
+ * Configure and preview the series grid.
+ *
+ * @param {Object}   props               Block props.
+ * @param {Object}   props.attributes    Block attributes.
+ * @param {Function} props.setAttributes Attribute setter.
+ * @return {Element} The editor preview.
+ */
+function Edit( { attributes, setAttributes } ) {
+	const blockProps = useBlockProps();
+
+	return (
+		<div { ...blockProps }>
+			<InspectorControls>
+				<PanelBody title={ __( 'Series', 'traktivity' ) }>
+					<RangeControl
+						__nextHasNoMarginBottom
+						label={ __( 'How many', 'traktivity' ) }
+						help={ __(
+							'Zero shows every series, for a full index page.',
+							'traktivity'
+						) }
+						min={ 0 }
+						max={ 48 }
+						value={ attributes.number }
+						onChange={ ( number ) => setAttributes( { number } ) }
+					/>
+					<SelectControl
+						__nextHasNoMarginBottom
+						label={ __( 'Order by', 'traktivity' ) }
+						value={ attributes.orderby }
+						options={ [
+							{
+								label: __( 'Episodes watched', 'traktivity' ),
+								value: 'count',
+							},
+							{
+								label: __( 'Name, A to Z', 'traktivity' ),
+								value: 'name',
+							},
+						] }
+						onChange={ ( orderby ) => setAttributes( { orderby } ) }
+					/>
+					<RangeControl
+						__nextHasNoMarginBottom
+						label={ __( 'Columns', 'traktivity' ) }
+						min={ 1 }
+						max={ 6 }
+						value={ attributes.columns }
+						onChange={ ( columns ) => setAttributes( { columns } ) }
+					/>
+				</PanelBody>
+				<PanelBody title={ __( 'Each series', 'traktivity' ) }>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Show artwork', 'traktivity' ) }
+						checked={ attributes.showImage }
+						onChange={ ( showImage ) =>
+							setAttributes( { showImage } )
+						}
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Show episode count', 'traktivity' ) }
+						checked={ attributes.showCount }
+						onChange={ ( showCount ) =>
+							setAttributes( { showCount } )
+						}
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Show network', 'traktivity' ) }
+						checked={ attributes.showNetwork }
+						onChange={ ( showNetwork ) =>
+							setAttributes( { showNetwork } )
+						}
+					/>
+					<RangeControl
+						__nextHasNoMarginBottom
+						label={ __( 'Heading level', 'traktivity' ) }
+						min={ 1 }
+						max={ 6 }
+						value={ attributes.headingLevel }
+						onChange={ ( headingLevel ) =>
+							setAttributes( { headingLevel: headingLevel || 3 } )
+						}
+					/>
+				</PanelBody>
+			</InspectorControls>
+
+			<ServerSideRender
+				block={ metadata.name }
+				attributes={ attributes }
+			/>
+		</div>
+	);
+}
+
+registerBlockType( metadata.name, { edit: Edit } );

--- a/src/blocks/top-shows/render.php
+++ b/src/blocks/top-shows/render.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Render the Top Series block.
+ *
+ * A Query Loop cannot express this: it orders posts, and this orders taxonomy
+ * terms by how many posts they hold.
+ *
+ * @package Traktivity
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block default content.
+ * @var WP_Block $block      Block instance.
+ */
+
+declare( strict_types = 1 );
+
+defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
+
+$traktivity_number  = isset( $attributes['number'] ) ? max( 0, (int) $attributes['number'] ) : 12;
+$traktivity_orderby = isset( $attributes['orderby'] ) && 'name' === $attributes['orderby'] ? 'name' : 'count';
+$traktivity_level   = isset( $attributes['headingLevel'] ) ? min( 6, max( 1, (int) $attributes['headingLevel'] ) ) : 3;
+$traktivity_columns = isset( $attributes['columns'] ) ? min( 6, max( 1, (int) $attributes['columns'] ) ) : 4;
+$traktivity_tag     = 'h' . $traktivity_level;
+
+$traktivity_shows = get_terms(
+	array(
+		'taxonomy'   => 'trakt_show',
+		'hide_empty' => true,
+		'orderby'    => $traktivity_orderby,
+		'order'      => 'count' === $traktivity_orderby ? 'DESC' : 'ASC',
+
+		/*
+		 * A number of 0 means "every series", which is what makes this block
+		 * usable as a full index on its own page. get_terms() reads 0 as
+		 * unlimited already, so it is passed through rather than translated.
+		 */
+		'number'     => $traktivity_number,
+	)
+);
+
+if ( is_wp_error( $traktivity_shows ) || empty( $traktivity_shows ) ) {
+	return;
+}
+
+$traktivity_wrapper = get_block_wrapper_attributes(
+	array(
+		'class' => 'traktivity-shows traktivity-shows--cols-' . $traktivity_columns,
+		'style' => '--traktivity-columns:' . $traktivity_columns,
+	)
+);
+?>
+<div <?php echo $traktivity_wrapper; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Prepared by get_block_wrapper_attributes(). ?>>
+	<?php
+	foreach ( $traktivity_shows as $traktivity_show ) :
+		$traktivity_link    = get_term_link( $traktivity_show );
+		$traktivity_link    = is_wp_error( $traktivity_link ) ? '' : (string) $traktivity_link;
+		$traktivity_poster  = traktivity_get_show_poster( $traktivity_show->term_id );
+		$traktivity_network = traktivity_get_show_network( $traktivity_show->term_id );
+
+		/*
+		 * The stored image is a 16:9 still from TMDb rather than the 2:3 poster
+		 * the meta key suggests, so it gets a landscape frame. A portrait one
+		 * crops faces off.
+		 */
+		$traktivity_art = Traktivity_Blocks::frame(
+			isset( $traktivity_poster['id'] ) ? (int) $traktivity_poster['id'] : 0,
+			$traktivity_show->name,
+			'landscape'
+		);
+		?>
+		<article class="traktivity-show">
+			<?php if ( ! isset( $attributes['showImage'] ) || $attributes['showImage'] ) : ?>
+				<a class="traktivity-show__link" href="<?php echo esc_url( $traktivity_link ); ?>" tabindex="-1" aria-hidden="true">
+					<?php echo $traktivity_art; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped in Traktivity_Blocks::frame(). ?>
+				</a>
+			<?php endif; ?>
+
+			<<?php echo esc_html( $traktivity_tag ); ?> class="traktivity-show__title">
+				<a href="<?php echo esc_url( $traktivity_link ); ?>"><?php echo esc_html( $traktivity_show->name ); ?></a>
+			</<?php echo esc_html( $traktivity_tag ); ?>>
+
+			<?php if ( ! isset( $attributes['showCount'] ) || $attributes['showCount'] ) : ?>
+				<p class="traktivity-show__count">
+					<?php
+					printf(
+						/* translators: %s: number of episodes. */
+						esc_html( _n( '%s episode', '%s episodes', (int) $traktivity_show->count, 'traktivity' ) ),
+						esc_html( number_format_i18n( (int) $traktivity_show->count ) )
+					);
+					?>
+				</p>
+			<?php endif; ?>
+
+			<?php if ( ( ! isset( $attributes['showNetwork'] ) || $attributes['showNetwork'] ) && '' !== $traktivity_network ) : ?>
+				<p class="traktivity-show__network"><?php echo esc_html( $traktivity_network ); ?></p>
+			<?php endif; ?>
+		</article>
+	<?php endforeach; ?>
+</div>

--- a/src/blocks/top-shows/style.scss
+++ b/src/blocks/top-shows/style.scss
@@ -1,0 +1,42 @@
+/**
+ * Top Series.
+ *
+ * The column count comes through as a custom property so the same stylesheet
+ * serves every setting, and auto-fit keeps it from breaking on a phone.
+ */
+
+.traktivity-shows {
+	display: grid;
+	gap: var(--wp--style--block-gap, 1.5em);
+	grid-template-columns: repeat(auto-fit, minmax(min(14rem, 100%), 1fr));
+}
+
+@media (min-width: 782px) {
+
+	.traktivity-shows {
+		grid-template-columns: repeat(var(--traktivity-columns, 4), 1fr);
+	}
+}
+
+.traktivity-show {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25em;
+}
+
+.traktivity-show__link {
+	display: block;
+	margin-bottom: 0.25em;
+	text-decoration: none;
+}
+
+.traktivity-show__title {
+	margin: 0;
+}
+
+.traktivity-show__count,
+.traktivity-show__network {
+	font-size: var(--wp--preset--font-size--small, 0.8125rem);
+	margin: 0;
+	opacity: 0.75;
+}

--- a/tests/package/verify-package.mjs
+++ b/tests/package/verify-package.mjs
@@ -110,6 +110,8 @@ for ( const required of [
 	'build/blocks/event-details/render.php',
 	'build/blocks/watch-stats/block.json',
 	'build/blocks/watch-stats/render.php',
+	'build/blocks/top-shows/block.json',
+	'build/blocks/top-shows/render.php',
 ] ) {
 	check( has( required ), `ships ${ required }` );
 }

--- a/tests/php/TopShowsBlockTest.php
+++ b/tests/php/TopShowsBlockTest.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * Tests for the Top Series block.
+ *
+ * @package Traktivity
+ */
+
+/**
+ * Ordering series by how many episodes have been logged.
+ */
+class TopShowsBlockTest extends WP_UnitTestCase {
+
+	/**
+	 * Register the block from its built directory, if there is one.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$built = TRAKTIVITY__PLUGIN_DIR . 'build/blocks/top-shows';
+
+		if ( ! WP_Block_Type_Registry::get_instance()->is_registered( 'traktivity/top-shows' ) && is_dir( $built ) ) {
+			register_block_type( $built );
+		}
+	}
+
+	/**
+	 * Create a series with a number of logged episodes.
+	 *
+	 * @param string $name     Series name.
+	 * @param int    $episodes How many episodes to log against it.
+	 * @param array  $meta     Term meta to attach.
+	 *
+	 * @return int Term ID.
+	 */
+	private function make_show( $name, $episodes, array $meta = array() ) {
+		$term = self::factory()->term->create_and_get(
+			array(
+				'taxonomy' => 'trakt_show',
+				'name'     => $name,
+			)
+		);
+
+		for ( $i = 0; $i < $episodes; $i++ ) {
+			$post_id = self::factory()->post->create(
+				array(
+					'post_type'   => 'traktivity_event',
+					'post_status' => 'publish',
+				)
+			);
+			update_post_meta( $post_id, 'trakt_show_id', $term->term_id );
+			wp_set_object_terms( $post_id, array( $name ), 'trakt_show' );
+		}
+
+		foreach ( $meta as $key => $value ) {
+			update_term_meta( $term->term_id, $key, $value );
+		}
+
+		return $term->term_id;
+	}
+
+	/**
+	 * Render the block.
+	 *
+	 * @param array $attrs Block attributes.
+	 *
+	 * @return string Rendered HTML.
+	 */
+	private function render( array $attrs = array() ) {
+		return render_block(
+			array(
+				'blockName'    => 'traktivity/top-shows',
+				'attrs'        => $attrs,
+				'innerHTML'    => '',
+				'innerBlocks'  => array(),
+				'innerContent' => array(),
+			)
+		);
+	}
+
+	/**
+	 * Series come back ordered by episode count, most first.
+	 */
+	public function test_ordered_by_count() {
+		$this->make_show( 'Fewer Episodes', 1 );
+		$this->make_show( 'More Episodes', 3 );
+
+		$html = $this->render();
+
+		$this->assertLessThan(
+			strpos( $html, 'Fewer Episodes' ),
+			strpos( $html, 'More Episodes' ),
+			'The series with more episodes comes first.'
+		);
+	}
+
+	/**
+	 * Ordering by name is available for an A to Z index.
+	 */
+	public function test_ordered_by_name() {
+		$this->make_show( 'Zed Series', 5 );
+		$this->make_show( 'Alpha Series', 1 );
+
+		$html = $this->render( array( 'orderby' => 'name' ) );
+
+		$this->assertLessThan(
+			strpos( $html, 'Zed Series' ),
+			strpos( $html, 'Alpha Series' ),
+			'Ordering by name runs A to Z regardless of count.'
+		);
+	}
+
+	/**
+	 * The number of series is limited.
+	 */
+	public function test_number_limits_the_grid() {
+		$this->make_show( 'One', 3 );
+		$this->make_show( 'Two', 2 );
+		$this->make_show( 'Three', 1 );
+
+		$this->assertSame( 2, substr_count( $this->render( array( 'number' => 2 ) ), 'class="traktivity-show"' ) );
+	}
+
+	/**
+	 * Zero means every series, which is what makes this usable as an index.
+	 */
+	public function test_zero_shows_everything() {
+		$this->make_show( 'One', 3 );
+		$this->make_show( 'Two', 2 );
+		$this->make_show( 'Three', 1 );
+
+		$this->assertSame( 3, substr_count( $this->render( array( 'number' => 0 ) ), 'class="traktivity-show"' ) );
+	}
+
+	/**
+	 * Series with nothing logged are left out.
+	 */
+	public function test_empty_series_are_hidden() {
+		$this->make_show( 'Watched', 2 );
+		self::factory()->term->create(
+			array(
+				'taxonomy' => 'trakt_show',
+				'name'     => 'Never Watched',
+			)
+		);
+
+		$html = $this->render();
+
+		$this->assertStringContainsString( 'Watched', $html );
+		$this->assertStringNotContainsString( 'Never Watched', $html );
+	}
+
+	/**
+	 * A series with no artwork gets the placeholder.
+	 */
+	public function test_missing_artwork_falls_back() {
+		$this->make_show( 'No Artwork', 1 );
+
+		$html = $this->render();
+
+		$this->assertStringContainsString( 'traktivity-frame--empty', $html );
+		$this->assertStringContainsString( 'No artwork', $html );
+	}
+
+	/**
+	 * The network is printed when there is one, and skipped when there is not.
+	 */
+	public function test_network() {
+		$this->make_show( 'With Network', 2, array( 'show_network' => 'Some Network' ) );
+
+		$this->assertStringContainsString( 'Some Network', $this->render() );
+		$this->assertStringNotContainsString( 'Some Network', $this->render( array( 'showNetwork' => false ) ) );
+	}
+
+	/**
+	 * A series with no network leaves no empty paragraph behind.
+	 */
+	public function test_missing_network_is_not_rendered() {
+		$this->make_show( 'No Network', 1 );
+
+		$this->assertStringNotContainsString( 'traktivity-show__network', $this->render() );
+	}
+
+	/**
+	 * Each series links to its archive.
+	 */
+	public function test_series_link_to_their_archive() {
+		$term_id = $this->make_show( 'Linked Series', 1 );
+
+		$this->assertStringContainsString( get_term_link( $term_id, 'trakt_show' ), $this->render() );
+	}
+
+	/**
+	 * The episode count is pluralised.
+	 */
+	public function test_counts_are_pluralised() {
+		$this->make_show( 'Just One', 1 );
+
+		$html = $this->render();
+
+		$this->assertStringContainsString( '1 episode', $html );
+		$this->assertStringNotContainsString( '1 episodes', $html );
+	}
+
+	/**
+	 * A site with no series renders nothing.
+	 */
+	public function test_no_series_renders_nothing() {
+		$this->assertSame( '', trim( $this->render() ) );
+	}
+
+	/**
+	 * The column count reaches the markup.
+	 */
+	public function test_columns() {
+		$this->make_show( 'A Series', 1 );
+
+		$html = $this->render( array( 'columns' => 3 ) );
+
+		$this->assertStringContainsString( 'traktivity-shows--cols-3', $html );
+		$this->assertStringContainsString( '--traktivity-columns:3', $html );
+	}
+}


### PR DESCRIPTION
Fixes #694

## What it does

Series ordered by how many episodes have been logged, rendered as a grid of
artwork, name, episode count and network.

Attributes: how many, order (count or name), columns, heading level, and toggles
for artwork, count and network.

## Rationale

Of every block in this milestone, this is the one with no alternative. A Query
Loop orders *posts*; this orders taxonomy terms by how many posts they hold,
which is a different query and one the editor has no way to ask for.

- **`number` of 0 means every series**, so the same block doubles as a full index
  on its own page rather than needing a second block for it. `get_terms()` already
  reads 0 as unlimited, so it's passed through rather than translated.
- **Ordering by name is there for that index**, which wants A to Z rather than a
  leaderboard.
- **The artwork gets a landscape frame.** The stored image is a 16:9 still from
  TMDb, not the 2:3 poster the `show_poster` key suggests, and a portrait frame
  crops faces off. Series with no image fall back to the shared placeholder.
- **`hide_empty`**, so a series with nothing logged doesn't appear, and a series
  with no network leaves no empty paragraph behind.
- **Columns travel as a custom property**, so one stylesheet serves every
  setting, and `auto-fit` takes over below the tablet breakpoint — a four-column
  grid shouldn't stay four columns on a phone.

## Usage

```html
<!-- wp:traktivity/top-shows {"number":12,"align":"wide"} /-->

<!-- A full A-Z index on its own page: -->
<!-- wp:traktivity/top-shows {"number":0,"orderby":"name","columns":5} /-->
```

## Testing

`composer run lint && composer run analyse` clean. PHPUnit 189 passing, 406
assertions. Build, package check and the JS gates all pass.

New coverage: ordering by count and by name, the number limiting the grid, zero
showing everything, empty series hidden, missing artwork falling back, the
network shown and hidden, a missing network leaving no markup, series linking to
their archives, counts pluralising, an empty site rendering nothing, and the
column count reaching the markup.
