### PR TITLE
Add a Latest Watch block for a homepage hero

### DIFF
--- a/src/blocks/latest-watch/block.json
+++ b/src/blocks/latest-watch/block.json
@@ -1,0 +1,31 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "traktivity/latest-watch",
+	"title": "Latest Watch",
+	"category": "traktivity",
+	"icon": "format-video",
+	"description": "The most recent thing watched, shown large.",
+	"textdomain": "traktivity",
+	"attributes": {
+		"kicker": { "type": "string", "default": "" },
+		"type": { "type": "string", "default": "any" },
+		"preferWithImage": { "type": "boolean", "default": true },
+		"headingLevel": { "type": "number", "default": 2 }
+	},
+	"supports": {
+		"html": false,
+		"reusable": false,
+		"align": [ "wide", "full" ],
+		"color": {
+			"background": true,
+			"text": true,
+			"link": true
+		},
+		"spacing": { "margin": true, "padding": true, "blockGap": true },
+		"typography": { "fontSize": true, "lineHeight": true }
+	},
+	"editorScript": "file:./index.js",
+	"style": [ "traktivity-shared", "file:./style-index.css" ],
+	"render": "file:./render.php"
+}

--- a/src/blocks/latest-watch/index.js
+++ b/src/blocks/latest-watch/index.js
@@ -1,0 +1,103 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	PanelBody,
+	RangeControl,
+	SelectControl,
+	TextControl,
+	ToggleControl,
+} from '@wordpress/components';
+import ServerSideRender from '@wordpress/server-side-render';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import './style.scss';
+
+/**
+ * Configure and preview the most recent watch.
+ *
+ * @param {Object}   props               Block props.
+ * @param {Object}   props.attributes    Block attributes.
+ * @param {Function} props.setAttributes Attribute setter.
+ * @return {Element} The editor preview.
+ */
+function Edit( { attributes, setAttributes } ) {
+	const blockProps = useBlockProps();
+
+	return (
+		<div { ...blockProps }>
+			<InspectorControls>
+				<PanelBody title={ __( 'Latest watch', 'traktivity' ) }>
+					<TextControl
+						__nextHasNoMarginBottom
+						label={ __( 'Label above', 'traktivity' ) }
+						help={ __(
+							'Something like "Just watched". Leave empty for none.',
+							'traktivity'
+						) }
+						value={ attributes.kicker }
+						onChange={ ( kicker ) => setAttributes( { kicker } ) }
+					/>
+					<SelectControl
+						__nextHasNoMarginBottom
+						label={ __( 'Limit to', 'traktivity' ) }
+						value={ attributes.type }
+						options={ [
+							{
+								label: __( 'Anything', 'traktivity' ),
+								value: 'any',
+							},
+							{
+								label: __( 'TV only', 'traktivity' ),
+								value: 'tv',
+							},
+							{
+								label: __( 'Films only', 'traktivity' ),
+								value: 'movie',
+							},
+						] }
+						onChange={ ( type ) => setAttributes( { type } ) }
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __(
+							'Prefer an entry with artwork',
+							'traktivity'
+						) }
+						help={ __(
+							'TMDb has no image for everything, and a large blank reads as broken. This picks the most recent entry that has one.',
+							'traktivity'
+						) }
+						checked={ attributes.preferWithImage }
+						onChange={ ( preferWithImage ) =>
+							setAttributes( { preferWithImage } )
+						}
+					/>
+					<RangeControl
+						__nextHasNoMarginBottom
+						label={ __( 'Heading level', 'traktivity' ) }
+						min={ 1 }
+						max={ 6 }
+						value={ attributes.headingLevel }
+						onChange={ ( headingLevel ) =>
+							setAttributes( { headingLevel: headingLevel || 2 } )
+						}
+					/>
+				</PanelBody>
+			</InspectorControls>
+
+			<ServerSideRender
+				block={ metadata.name }
+				attributes={ attributes }
+			/>
+		</div>
+	);
+}
+
+registerBlockType( metadata.name, { edit: Edit } );

--- a/src/blocks/latest-watch/render.php
+++ b/src/blocks/latest-watch/render.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Render the Latest Watch block.
+ *
+ * @package Traktivity
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block default content.
+ * @var WP_Block $block      Block instance.
+ */
+
+declare( strict_types = 1 );
+
+defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
+
+$traktivity_type  = isset( $attributes['type'] ) ? (string) $attributes['type'] : 'any';
+$traktivity_level = isset( $attributes['headingLevel'] ) ? min( 6, max( 1, (int) $attributes['headingLevel'] ) ) : 2;
+$traktivity_tag   = 'h' . $traktivity_level;
+
+$traktivity_args = array(
+	'post_type'      => 'traktivity_event',
+	'post_status'    => 'publish',
+	'posts_per_page' => 1,
+	'fields'         => 'ids',
+	'no_found_rows'  => true,
+);
+
+/*
+ * Restricting by type reads the ID meta rather than the trakt_type taxonomy,
+ * whose term names the sync builds from a translated string. Filtering on the
+ * taxonomy would quietly return nothing on any site not running in English.
+ */
+$traktivity_meta = array();
+
+if ( 'tv' === $traktivity_type ) {
+	$traktivity_meta[] = array(
+		'key'     => 'trakt_show_id',
+		'compare' => 'EXISTS',
+	);
+} elseif ( 'movie' === $traktivity_type ) {
+	$traktivity_meta[] = array(
+		'key'     => 'trakt_movie_id',
+		'compare' => 'EXISTS',
+	);
+}
+
+/*
+ * A hero with a placeholder where the artwork should be looks broken, and
+ * plenty of events never get an image from TMDb. So the newest event that has
+ * one is preferred, and the newest of any kind is the fallback when none does.
+ */
+$traktivity_latest = array();
+
+if ( ! isset( $attributes['preferWithImage'] ) || $attributes['preferWithImage'] ) {
+	$traktivity_with_image   = $traktivity_meta;
+	$traktivity_with_image[] = array(
+		'key'     => '_thumbnail_id',
+		'compare' => 'EXISTS',
+	);
+
+	$traktivity_latest = get_posts(
+		array_merge(
+			$traktivity_args,
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Indexed meta keys, one row.
+			array( 'meta_query' => $traktivity_with_image )
+		)
+	);
+}
+
+if ( empty( $traktivity_latest ) ) {
+	if ( ! empty( $traktivity_meta ) ) {
+		// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Indexed meta key, one row.
+		$traktivity_args['meta_query'] = $traktivity_meta;
+	}
+
+	$traktivity_latest = get_posts( $traktivity_args );
+}
+
+if ( empty( $traktivity_latest ) ) {
+	return;
+}
+
+$traktivity_event  = traktivity_get_event( (int) $traktivity_latest[0] );
+$traktivity_kicker = isset( $attributes['kicker'] ) ? (string) $attributes['kicker'] : '';
+
+$traktivity_wrapper = get_block_wrapper_attributes( array( 'class' => 'traktivity-hero' ) );
+?>
+<section <?php echo $traktivity_wrapper; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Prepared by get_block_wrapper_attributes(). ?>>
+	<?php if ( '' !== $traktivity_kicker ) : ?>
+		<p class="traktivity-hero__kicker"><?php echo esc_html( $traktivity_kicker ); ?></p>
+	<?php endif; ?>
+
+	<a class="traktivity-hero__link" href="<?php echo esc_url( $traktivity_event['permalink'] ); ?>" tabindex="-1" aria-hidden="true">
+		<?php echo Traktivity_Blocks::frame( $traktivity_event['image_id'], $traktivity_event['title'], 'landscape' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped in Traktivity_Blocks::frame(). ?>
+	</a>
+
+	<div class="traktivity-hero__body">
+		<?php if ( '' !== $traktivity_event['show_name'] && '' !== $traktivity_event['show_link'] ) : ?>
+			<p class="traktivity-hero__show">
+				<a href="<?php echo esc_url( $traktivity_event['show_link'] ); ?>"><?php echo esc_html( $traktivity_event['show_name'] ); ?></a>
+			</p>
+		<?php endif; ?>
+
+		<<?php echo esc_html( $traktivity_tag ); ?> class="traktivity-hero__title">
+			<a href="<?php echo esc_url( $traktivity_event['permalink'] ); ?>">
+				<?php if ( '' !== $traktivity_event['episode_code'] ) : ?>
+					<span class="traktivity-hero__code"><?php echo esc_html( $traktivity_event['episode_code'] ); ?></span>
+				<?php endif; ?>
+				<?php echo esc_html( $traktivity_event['title'] ); ?>
+			</a>
+		</<?php echo esc_html( $traktivity_tag ); ?>>
+
+		<p class="traktivity-hero__meta">
+			<time datetime="<?php echo esc_attr( $traktivity_event['watched_iso'] ); ?>"><?php echo esc_html( $traktivity_event['watched'] ); ?></time>
+			<?php if ( $traktivity_event['runtime'] > 0 ) : ?>
+				<span class="traktivity-sep" aria-hidden="true">&middot;</span>
+				<?php
+				printf(
+					/* translators: %d: number of minutes. */
+					esc_html( _n( '%d min', '%d min', $traktivity_event['runtime'], 'traktivity' ) ),
+					(int) $traktivity_event['runtime']
+				);
+				?>
+			<?php endif; ?>
+		</p>
+	</div>
+</section>

--- a/src/blocks/latest-watch/style.scss
+++ b/src/blocks/latest-watch/style.scss
@@ -1,0 +1,60 @@
+/**
+ * Latest Watch.
+ *
+ * Side by side once there is room, stacked below that. The image keeps its
+ * ratio from the shared frame rules.
+ */
+
+.traktivity-hero {
+	display: grid;
+	gap: var(--wp--style--block-gap, 1.5em);
+}
+
+@media (min-width: 782px) {
+
+	.traktivity-hero {
+		align-items: center;
+		grid-template-columns: 3fr 2fr;
+	}
+}
+
+.traktivity-hero__link {
+	display: block;
+	text-decoration: none;
+}
+
+.traktivity-hero__kicker {
+	font-size: var(--wp--preset--font-size--small, 0.8125rem);
+	letter-spacing: 0.1em;
+	margin: 0;
+	opacity: 0.7;
+	text-transform: uppercase;
+}
+
+.traktivity-hero__body {
+	display: flex;
+	flex-direction: column;
+	gap: 0.35em;
+}
+
+.traktivity-hero__show {
+	font-size: var(--wp--preset--font-size--small, 0.8125rem);
+	letter-spacing: 0.06em;
+	margin: 0;
+	text-transform: uppercase;
+}
+
+.traktivity-hero__title {
+	margin: 0;
+}
+
+.traktivity-hero__code {
+	opacity: 0.7;
+	white-space: nowrap;
+}
+
+.traktivity-hero__meta {
+	font-size: var(--wp--preset--font-size--small, 0.8125rem);
+	margin: 0;
+	opacity: 0.75;
+}

--- a/tests/package/verify-package.mjs
+++ b/tests/package/verify-package.mjs
@@ -112,6 +112,8 @@ for ( const required of [
 	'build/blocks/watch-stats/render.php',
 	'build/blocks/top-shows/block.json',
 	'build/blocks/top-shows/render.php',
+	'build/blocks/latest-watch/block.json',
+	'build/blocks/latest-watch/render.php',
 ] ) {
 	check( has( required ), `ships ${ required }` );
 }

--- a/tests/php/LatestWatchBlockTest.php
+++ b/tests/php/LatestWatchBlockTest.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Tests for the Latest Watch block.
+ *
+ * @package Traktivity
+ */
+
+/**
+ * Showing the most recent thing watched.
+ */
+class LatestWatchBlockTest extends WP_UnitTestCase {
+
+	/**
+	 * Register the block from its built directory, if there is one.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$built = TRAKTIVITY__PLUGIN_DIR . 'build/blocks/latest-watch';
+
+		if ( ! WP_Block_Type_Registry::get_instance()->is_registered( 'traktivity/latest-watch' ) && is_dir( $built ) ) {
+			register_block_type( $built );
+		}
+	}
+
+	/**
+	 * Create a published event.
+	 *
+	 * @param string $id_key    Either trakt_show_id or trakt_movie_id.
+	 * @param string $date      Post date.
+	 * @param string $title     Post title.
+	 * @param bool   $has_image Whether to attach a featured image.
+	 *
+	 * @return int Post ID.
+	 */
+	private function make_event( $id_key, $date, $title, $has_image = false ) {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'traktivity_event',
+				'post_status' => 'publish',
+				'post_date'   => $date,
+				'post_title'  => $title,
+			)
+		);
+
+		update_post_meta( $post_id, $id_key, 1 );
+
+		if ( $has_image ) {
+			$attachment = self::factory()->attachment->create_object(
+				array(
+					'file'           => 'still.jpg',
+					'post_parent'    => $post_id,
+					'post_mime_type' => 'image/jpeg',
+				)
+			);
+			set_post_thumbnail( $post_id, $attachment );
+		}
+
+		return $post_id;
+	}
+
+	/**
+	 * Render the block.
+	 *
+	 * @param array $attrs Block attributes.
+	 *
+	 * @return string Rendered HTML.
+	 */
+	private function render( array $attrs = array() ) {
+		return render_block(
+			array(
+				'blockName'    => 'traktivity/latest-watch',
+				'attrs'        => $attrs,
+				'innerHTML'    => '',
+				'innerBlocks'  => array(),
+				'innerContent' => array(),
+			)
+		);
+	}
+
+	/**
+	 * The most recent event is the one rendered.
+	 */
+	public function test_most_recent_event_is_shown() {
+		$this->make_event( 'trakt_show_id', '2022-01-01 10:00:00', 'Older Episode' );
+		$this->make_event( 'trakt_show_id', '2026-03-04 20:00:00', 'Newer Episode' );
+
+		$html = $this->render();
+
+		$this->assertStringContainsString( 'Newer Episode', $html );
+		$this->assertStringNotContainsString( 'Older Episode', $html );
+	}
+
+	/**
+	 * An entry with artwork wins over a newer one without.
+	 *
+	 * A large blank where the artwork should be reads as broken, and TMDb has
+	 * no image for plenty of entries.
+	 */
+	public function test_entry_with_artwork_is_preferred() {
+		$this->make_event( 'trakt_show_id', '2026-01-01 10:00:00', 'Has Artwork', true );
+		$this->make_event( 'trakt_show_id', '2026-03-04 20:00:00', 'No Artwork' );
+
+		$html = $this->render();
+
+		$this->assertStringContainsString( 'Has Artwork', $html );
+		$this->assertStringNotContainsString( 'No Artwork<', $html );
+	}
+
+	/**
+	 * With no artwork anywhere, the newest entry is shown regardless.
+	 */
+	public function test_falls_back_when_nothing_has_artwork() {
+		$this->make_event( 'trakt_show_id', '2026-03-04 20:00:00', 'Newest Episode' );
+
+		$html = $this->render();
+
+		$this->assertStringContainsString( 'Newest Episode', $html );
+		$this->assertStringContainsString( 'traktivity-frame--empty', $html );
+	}
+
+	/**
+	 * The preference can be turned off, giving the newest entry outright.
+	 */
+	public function test_preference_can_be_turned_off() {
+		$this->make_event( 'trakt_show_id', '2026-01-01 10:00:00', 'Has Artwork', true );
+		$this->make_event( 'trakt_show_id', '2026-03-04 20:00:00', 'Newest Episode' );
+
+		$html = $this->render( array( 'preferWithImage' => false ) );
+
+		$this->assertStringContainsString( 'Newest Episode', $html );
+	}
+
+	/**
+	 * The block can be restricted to TV or to films.
+	 */
+	public function test_type_can_be_restricted() {
+		$this->make_event( 'trakt_show_id', '2026-01-01 10:00:00', 'An Episode' );
+		$this->make_event( 'trakt_movie_id', '2026-03-04 20:00:00', 'A Film' );
+
+		$tv = $this->render( array( 'type' => 'tv' ) );
+		$this->assertStringContainsString( 'An Episode', $tv );
+		$this->assertStringNotContainsString( 'A Film', $tv );
+
+		$films = $this->render( array( 'type' => 'movie' ) );
+		$this->assertStringContainsString( 'A Film', $films );
+		$this->assertStringNotContainsString( 'An Episode', $films );
+	}
+
+	/**
+	 * A site with nothing logged renders nothing.
+	 */
+	public function test_empty_site_renders_nothing() {
+		$this->assertSame( '', trim( $this->render() ) );
+	}
+
+	/**
+	 * A type with nothing logged renders nothing rather than the wrong thing.
+	 */
+	public function test_empty_type_renders_nothing() {
+		$this->make_event( 'trakt_show_id', '2026-03-04 20:00:00', 'An Episode' );
+
+		$this->assertSame( '', trim( $this->render( array( 'type' => 'movie' ) ) ) );
+	}
+
+	/**
+	 * The label above the entry is optional.
+	 */
+	public function test_kicker() {
+		$this->make_event( 'trakt_show_id', '2026-03-04 20:00:00', 'An Episode' );
+
+		$this->assertStringContainsString( 'Just watched', $this->render( array( 'kicker' => 'Just watched' ) ) );
+		$this->assertStringNotContainsString( 'traktivity-hero__kicker', $this->render() );
+	}
+
+	/**
+	 * The image link is skipped by the keyboard, since the title repeats it.
+	 */
+	public function test_image_link_is_not_a_second_tab_stop() {
+		$this->make_event( 'trakt_show_id', '2026-03-04 20:00:00', 'An Episode' );
+
+		$html = $this->render();
+
+		$this->assertStringContainsString( 'tabindex="-1"', $html );
+		$this->assertStringContainsString( 'aria-hidden="true"', $html );
+	}
+
+	/**
+	 * The heading level is configurable and clamped.
+	 */
+	public function test_heading_level() {
+		$this->make_event( 'trakt_show_id', '2026-03-04 20:00:00', 'An Episode' );
+
+		$this->assertStringContainsString( '<h4', $this->render( array( 'headingLevel' => 4 ) ) );
+		$this->assertStringContainsString( '<h6', $this->render( array( 'headingLevel' => 88 ) ) );
+	}
+}


### PR DESCRIPTION
Fixes #695

## What it does

The most recent thing watched, shown large. Runs its own query rather than
relying on block context, so it can sit anywhere.

Attributes: an optional label above, a type restriction, whether to prefer an
entry with artwork, and the heading level.

## Rationale

**It prefers the newest entry that actually has artwork.** A hero is mostly
image, TMDb has nothing for a fair share of entries, and a large blank where the
picture should be reads as broken rather than as empty. That's a
`_thumbnail_id EXISTS` check on a single row, so it costs nothing, and it falls
back to the newest entry of any kind when nothing has an image. It's an
attribute rather than forced behaviour, for anyone who'd rather have strict
recency.

**Restricting to TV or films reads the ID meta, not `trakt_type`.** The sync
builds those term names from a translated string, so filtering on the taxonomy
would quietly return nothing on any site not running in English. Same reasoning
as #684 and #688.

**Same duplicate-link fix as the event card:** the image and the title point at
the same place, so the image link is out of the tab order.

An empty site renders nothing, and so does a type with nothing logged — better
than showing a film where someone asked for TV.

## Also in here

One blank line added inside a media query in the Top Series stylesheet.
stylelint's `rule-empty-line-before` only fires on the first rule inside a block,
so #694 didn't trip it and this branch did.

## Usage

```html
<!-- wp:traktivity/latest-watch {"kicker":"Just watched","align":"wide"} /-->

<!-- Most recent film, strict recency: -->
<!-- wp:traktivity/latest-watch {"type":"movie","preferWithImage":false} /-->
```

## Testing

`composer run lint && composer run analyse` clean. PHPUnit 199 passing, 425
assertions. Build, package check and the JS gates all pass.

New coverage: the most recent entry rendering, artwork being preferred over
recency, the fallback when nothing has artwork, the preference turned off, both
type restrictions, an empty site, an empty type, the optional label, the image
link not being a second tab stop, and the heading level being configurable and
clamped.
