### PR TITLE
Add a Series Header block, and finish the block set

### DIFF
--- a/src/blocks/show-header/block.json
+++ b/src/blocks/show-header/block.json
@@ -1,0 +1,33 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "traktivity/show-header",
+	"title": "Series Header",
+	"category": "traktivity",
+	"icon": "album",
+	"description": "Artwork, network, totals and synopsis for the series being viewed.",
+	"textdomain": "traktivity",
+	"attributes": {
+		"showImage": { "type": "boolean", "default": true },
+		"showNetwork": { "type": "boolean", "default": true },
+		"showStats": { "type": "boolean", "default": true },
+		"showSynopsis": { "type": "boolean", "default": true },
+		"showLinks": { "type": "boolean", "default": false },
+		"headingLevel": { "type": "number", "default": 1 }
+	},
+	"supports": {
+		"html": false,
+		"reusable": false,
+		"align": [ "wide" ],
+		"color": {
+			"background": true,
+			"text": true,
+			"link": true
+		},
+		"spacing": { "margin": true, "padding": true, "blockGap": true },
+		"typography": { "fontSize": true, "lineHeight": true }
+	},
+	"editorScript": "file:./index.js",
+	"style": [ "traktivity-shared", "file:./style-index.css" ],
+	"render": "file:./render.php"
+}

--- a/src/blocks/show-header/index.js
+++ b/src/blocks/show-header/index.js
@@ -1,0 +1,114 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	Notice,
+	PanelBody,
+	RangeControl,
+	ToggleControl,
+} from '@wordpress/components';
+import ServerSideRender from '@wordpress/server-side-render';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import './style.scss';
+
+/**
+ * Configure the series header.
+ *
+ * The block reads the queried series, which only exists on a series archive.
+ * Anywhere else the server render is empty, so the editor says why rather than
+ * leaving a blank area that looks like a bug.
+ *
+ * @param {Object}   props               Block props.
+ * @param {Object}   props.attributes    Block attributes.
+ * @param {Function} props.setAttributes Attribute setter.
+ * @return {Element} The editor preview.
+ */
+function Edit( { attributes, setAttributes } ) {
+	const blockProps = useBlockProps();
+
+	return (
+		<div { ...blockProps }>
+			<InspectorControls>
+				<PanelBody title={ __( 'Series header', 'traktivity' ) }>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Show artwork', 'traktivity' ) }
+						checked={ attributes.showImage }
+						onChange={ ( showImage ) =>
+							setAttributes( { showImage } )
+						}
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Show network', 'traktivity' ) }
+						checked={ attributes.showNetwork }
+						onChange={ ( showNetwork ) =>
+							setAttributes( { showNetwork } )
+						}
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __(
+							'Show episodes and time watched',
+							'traktivity'
+						) }
+						checked={ attributes.showStats }
+						onChange={ ( showStats ) =>
+							setAttributes( { showStats } )
+						}
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Show synopsis', 'traktivity' ) }
+						checked={ attributes.showSynopsis }
+						onChange={ ( showSynopsis ) =>
+							setAttributes( { showSynopsis } )
+						}
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __(
+							'Show links to Trakt.tv, IMDb and TMDb',
+							'traktivity'
+						) }
+						checked={ attributes.showLinks }
+						onChange={ ( showLinks ) =>
+							setAttributes( { showLinks } )
+						}
+					/>
+					<RangeControl
+						__nextHasNoMarginBottom
+						label={ __( 'Heading level', 'traktivity' ) }
+						min={ 1 }
+						max={ 6 }
+						value={ attributes.headingLevel }
+						onChange={ ( headingLevel ) =>
+							setAttributes( { headingLevel: headingLevel || 1 } )
+						}
+					/>
+				</PanelBody>
+			</InspectorControls>
+
+			<Notice status="info" isDismissible={ false }>
+				{ __(
+					'This header fills in on a series archive. It stays empty everywhere else.',
+					'traktivity'
+				) }
+			</Notice>
+
+			<ServerSideRender
+				block={ metadata.name }
+				attributes={ attributes }
+			/>
+		</div>
+	);
+}
+
+registerBlockType( metadata.name, { edit: Edit } );

--- a/src/blocks/show-header/render.php
+++ b/src/blocks/show-header/render.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Render the Series Header block.
+ *
+ * @package Traktivity
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block default content.
+ * @var WP_Block $block      Block instance.
+ */
+
+declare( strict_types = 1 );
+
+defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
+
+$traktivity_term = get_queried_object();
+
+/*
+ * A template block for one archive. Anywhere else there is no series to
+ * describe, so it renders nothing rather than guessing at one.
+ */
+if ( ! $traktivity_term instanceof WP_Term || 'trakt_show' !== $traktivity_term->taxonomy ) {
+	return;
+}
+
+$traktivity_level   = isset( $attributes['headingLevel'] ) ? min( 6, max( 1, (int) $attributes['headingLevel'] ) ) : 1;
+$traktivity_tag     = 'h' . $traktivity_level;
+$traktivity_poster  = traktivity_get_show_poster( $traktivity_term->term_id );
+$traktivity_network = traktivity_get_show_network( $traktivity_term->term_id );
+$traktivity_minutes = traktivity_get_show_runtime( $traktivity_term->term_id );
+$traktivity_runtime = $traktivity_minutes > 0 ? Traktivity_Stats::convert_time( $traktivity_minutes ) : '';
+
+/*
+ * A 16:9 still from TMDb rather than the 2:3 poster the meta key suggests, so
+ * it gets a landscape frame. Built here rather than inline below, so the
+ * escaping annotation sits on one line the sniff can read.
+ */
+$traktivity_art = Traktivity_Blocks::frame(
+	isset( $traktivity_poster['id'] ) ? (int) $traktivity_poster['id'] : 0,
+	$traktivity_term->name,
+	'landscape'
+);
+
+$traktivity_wrapper = get_block_wrapper_attributes( array( 'class' => 'traktivity-showhead' ) );
+?>
+<header <?php echo $traktivity_wrapper; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Prepared by get_block_wrapper_attributes(). ?>>
+	<?php if ( ! isset( $attributes['showImage'] ) || $attributes['showImage'] ) : ?>
+		<div class="traktivity-showhead__art">
+			<?php echo $traktivity_art; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped in Traktivity_Blocks::frame(). ?>
+		</div>
+	<?php endif; ?>
+
+	<div class="traktivity-showhead__body">
+		<?php if ( ( ! isset( $attributes['showNetwork'] ) || $attributes['showNetwork'] ) && '' !== $traktivity_network ) : ?>
+			<p class="traktivity-showhead__network"><?php echo esc_html( $traktivity_network ); ?></p>
+		<?php endif; ?>
+
+		<<?php echo esc_html( $traktivity_tag ); ?> class="traktivity-showhead__title"><?php echo esc_html( $traktivity_term->name ); ?></<?php echo esc_html( $traktivity_tag ); ?>>
+
+		<?php if ( ! isset( $attributes['showStats'] ) || $attributes['showStats'] ) : ?>
+			<p class="traktivity-showhead__stats">
+				<?php
+				printf(
+					/* translators: %s: number of episodes. */
+					esc_html( _n( '%s episode watched', '%s episodes watched', (int) $traktivity_term->count, 'traktivity' ) ),
+					esc_html( number_format_i18n( (int) $traktivity_term->count ) )
+				);
+				?>
+				<?php if ( '' !== $traktivity_runtime ) : ?>
+					<span class="traktivity-sep" aria-hidden="true">&middot;</span>
+					<?php echo esc_html( $traktivity_runtime ); ?>
+				<?php endif; ?>
+			</p>
+		<?php endif; ?>
+
+		<?php if ( ( ! isset( $attributes['showSynopsis'] ) || $attributes['showSynopsis'] ) && '' !== $traktivity_term->description ) : ?>
+			<?php
+			/*
+			 * The sync stores this as plain text, but WordPress allows limited
+			 * markup in a term description and a site owner may well have
+			 * edited one. wp_kses_post() keeps their formatting rather than
+			 * printing their tags at them.
+			 */
+			?>
+			<div class="traktivity-showhead__synopsis"><?php echo wp_kses_post( wpautop( $traktivity_term->description ) ); ?></div>
+		<?php endif; ?>
+
+		<?php
+		if ( ! empty( $attributes['showLinks'] ) ) :
+			$traktivity_links = traktivity_get_show_links( $traktivity_term->term_id );
+			?>
+			<?php if ( ! empty( $traktivity_links ) ) : ?>
+				<p class="traktivity-showhead__links">
+					<?php
+					$traktivity_rendered = array();
+
+					foreach ( $traktivity_links as $traktivity_link ) {
+						$traktivity_rendered[] = sprintf(
+							'<a href="%1$s">%2$s</a>',
+							esc_url( $traktivity_link['url'] ),
+							esc_html( $traktivity_link['label'] )
+						);
+					}
+
+					echo implode( ' <span class="traktivity-sep" aria-hidden="true">&middot;</span> ', $traktivity_rendered ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Each link is escaped as it is built above.
+					?>
+				</p>
+			<?php endif; ?>
+		<?php endif; ?>
+	</div>
+</header>

--- a/src/blocks/show-header/style.scss
+++ b/src/blocks/show-header/style.scss
@@ -1,0 +1,51 @@
+/**
+ * Series Header.
+ *
+ * Artwork beside the details once there is room, stacked below that.
+ */
+
+.traktivity-showhead {
+	display: grid;
+	gap: var(--wp--style--block-gap, 1.5em);
+}
+
+@media (min-width: 782px) {
+
+	.traktivity-showhead {
+		align-items: start;
+		grid-template-columns: 2fr 3fr;
+	}
+}
+
+.traktivity-showhead__body {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5em;
+}
+
+.traktivity-showhead__network {
+	font-size: var(--wp--preset--font-size--small, 0.8125rem);
+	letter-spacing: 0.1em;
+	margin: 0;
+	opacity: 0.7;
+	text-transform: uppercase;
+}
+
+.traktivity-showhead__title {
+	margin: 0;
+}
+
+.traktivity-showhead__stats,
+.traktivity-showhead__links {
+	font-size: var(--wp--preset--font-size--small, 0.8125rem);
+	margin: 0;
+	opacity: 0.8;
+}
+
+.traktivity-showhead__synopsis p {
+	margin: 0 0 0.75em;
+}
+
+.traktivity-showhead__synopsis p:last-child {
+	margin-bottom: 0;
+}

--- a/tests/package/verify-package.mjs
+++ b/tests/package/verify-package.mjs
@@ -114,6 +114,8 @@ for ( const required of [
 	'build/blocks/top-shows/render.php',
 	'build/blocks/latest-watch/block.json',
 	'build/blocks/latest-watch/render.php',
+	'build/blocks/show-header/block.json',
+	'build/blocks/show-header/render.php',
 ] ) {
 	check( has( required ), `ships ${ required }` );
 }

--- a/tests/php/ShowHeaderBlockTest.php
+++ b/tests/php/ShowHeaderBlockTest.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * Tests for the Series Header block.
+ *
+ * @package Traktivity
+ */
+
+/**
+ * Describing the series whose archive is being viewed.
+ */
+class ShowHeaderBlockTest extends WP_UnitTestCase {
+
+	/**
+	 * Register the block from its built directory, if there is one.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$built = TRAKTIVITY__PLUGIN_DIR . 'build/blocks/show-header';
+
+		if ( ! WP_Block_Type_Registry::get_instance()->is_registered( 'traktivity/show-header' ) && is_dir( $built ) ) {
+			register_block_type( $built );
+		}
+	}
+
+	/**
+	 * Create a series with episodes logged against it.
+	 *
+	 * @param string $name        Series name.
+	 * @param int    $episodes    How many episodes to log.
+	 * @param array  $meta        Term meta.
+	 * @param string $description Term description.
+	 *
+	 * @return WP_Term The series.
+	 */
+	private function make_show( $name, $episodes = 2, array $meta = array(), $description = '' ) {
+		$term = self::factory()->term->create_and_get(
+			array(
+				'taxonomy'    => 'trakt_show',
+				'name'        => $name,
+				'description' => $description,
+			)
+		);
+
+		for ( $i = 0; $i < $episodes; $i++ ) {
+			$post_id = self::factory()->post->create(
+				array(
+					'post_type'   => 'traktivity_event',
+					'post_status' => 'publish',
+				)
+			);
+			update_post_meta( $post_id, 'trakt_show_id', $term->term_id );
+			wp_set_object_terms( $post_id, array( $name ), 'trakt_show' );
+		}
+
+		foreach ( $meta as $key => $value ) {
+			update_term_meta( $term->term_id, $key, $value );
+		}
+
+		return get_term( $term->term_id, 'trakt_show' );
+	}
+
+	/**
+	 * Render the block as if on that series' archive.
+	 *
+	 * @param WP_Term|null $term  Series being viewed, or null for no archive.
+	 * @param array        $attrs Block attributes.
+	 *
+	 * @return string Rendered HTML.
+	 */
+	private function render( $term, array $attrs = array() ) {
+		$previous = $GLOBALS['wp_query'];
+
+		$GLOBALS['wp_query'] = new WP_Query();
+
+		if ( $term instanceof WP_Term ) {
+			$GLOBALS['wp_query']->is_tax            = true;
+			$GLOBALS['wp_query']->queried_object    = $term;
+			$GLOBALS['wp_query']->queried_object_id = $term->term_id;
+		}
+
+		$html = render_block(
+			array(
+				'blockName'    => 'traktivity/show-header',
+				'attrs'        => $attrs,
+				'innerHTML'    => '',
+				'innerBlocks'  => array(),
+				'innerContent' => array(),
+			)
+		);
+
+		$GLOBALS['wp_query'] = $previous;
+
+		return $html;
+	}
+
+	/**
+	 * A series archive gets a full header.
+	 */
+	public function test_full_header() {
+		$term = $this->make_show(
+			'Some Series',
+			3,
+			array(
+				'show_network' => 'Some Network',
+				'show_runtime' => 180,
+			),
+			'A description of the series.'
+		);
+
+		$html = $this->render( $term );
+
+		$this->assertStringContainsString( 'Some Series', $html );
+		$this->assertStringContainsString( 'Some Network', $html );
+		$this->assertStringContainsString( '3 episodes watched', $html );
+		$this->assertStringContainsString( '3 hours', $html );
+		$this->assertStringContainsString( 'A description of the series.', $html );
+		$this->assertStringContainsString( '<h1', $html );
+	}
+
+	/**
+	 * Anywhere that is not a series archive renders nothing.
+	 */
+	public function test_renders_nothing_off_a_series_archive() {
+		$this->make_show( 'Some Series' );
+
+		$this->assertSame( '', trim( $this->render( null ) ) );
+	}
+
+	/**
+	 * Another taxonomy's archive renders nothing either.
+	 */
+	public function test_renders_nothing_on_another_taxonomy() {
+		$genre = self::factory()->term->create_and_get(
+			array(
+				'taxonomy' => 'trakt_genre',
+				'name'     => 'Drama',
+			)
+		);
+
+		$this->assertSame( '', trim( $this->render( $genre ) ) );
+	}
+
+	/**
+	 * A series with nothing but a name still renders.
+	 */
+	public function test_bare_series() {
+		$term = $this->make_show( 'Bare Series', 1 );
+
+		$html = $this->render( $term );
+
+		$this->assertStringContainsString( 'Bare Series', $html );
+		$this->assertStringContainsString( '1 episode watched', $html );
+		$this->assertStringContainsString( 'traktivity-frame--empty', $html );
+		$this->assertStringNotContainsString( 'traktivity-showhead__network', $html );
+		$this->assertStringNotContainsString( 'traktivity-showhead__synopsis', $html );
+	}
+
+	/**
+	 * Each part can be turned off.
+	 */
+	public function test_parts_can_be_hidden() {
+		$term = $this->make_show(
+			'Some Series',
+			2,
+			array(
+				'show_network' => 'Some Network',
+				'show_runtime' => 120,
+			),
+			'A description.'
+		);
+
+		$this->assertStringNotContainsString( 'Some Network', $this->render( $term, array( 'showNetwork' => false ) ) );
+		$this->assertStringNotContainsString( 'A description.', $this->render( $term, array( 'showSynopsis' => false ) ) );
+		$this->assertStringNotContainsString( 'episodes watched', $this->render( $term, array( 'showStats' => false ) ) );
+		$this->assertStringNotContainsString( 'traktivity-frame', $this->render( $term, array( 'showImage' => false ) ) );
+	}
+
+	/**
+	 * External links are off by default and available on request.
+	 */
+	public function test_links() {
+		$term = $this->make_show(
+			'Linked Series',
+			1,
+			array(
+				'show_external_ids' => array(
+					'trakt' => 111,
+					'imdb'  => 'tt1234567',
+				),
+			)
+		);
+
+		$this->assertStringNotContainsString( 'imdb.com', $this->render( $term ) );
+		$this->assertStringContainsString( 'imdb.com', $this->render( $term, array( 'showLinks' => true ) ) );
+	}
+
+	/**
+	 * The heading level is configurable and clamped.
+	 */
+	public function test_heading_level() {
+		$term = $this->make_show( 'Some Series', 1 );
+
+		$this->assertStringContainsString( '<h2', $this->render( $term, array( 'headingLevel' => 2 ) ) );
+		$this->assertStringContainsString( '<h6', $this->render( $term, array( 'headingLevel' => 77 ) ) );
+	}
+
+	/**
+	 * A synopsis someone has formatted keeps its formatting.
+	 *
+	 * The sync writes plain text, but WordPress allows limited markup in a
+	 * term description and a site owner may well have edited one.
+	 */
+	public function test_synopsis_keeps_safe_markup() {
+		$term = $this->make_show( 'Formatted Series', 1, array(), 'A <em>formatted</em> description.' );
+
+		$html = $this->render( $term );
+
+		$this->assertStringContainsString( '<em>formatted</em>', $html );
+	}
+}


### PR DESCRIPTION
Fixes #696

## What it does

The header for a series archive: artwork, network, series name, episodes
watched, total time watched, synopsis, and optionally links out to Trakt.tv, IMDb
and TMDb.

This is the last of the seven blocks in the milestone.

## Rationale

A `trakt_show` archive gets whatever the theme's generic taxonomy template
offers, which is a term title and a description. Everything else the sync stored
about that series sits unused.

- **It's a template block for one archive**, so it bails out unless the queried
  object is a `trakt_show` term. Anywhere else there's no series to describe, and
  it renders nothing rather than guessing at one. The editor shows a notice
  saying so, because a block that's deliberately empty in the editor otherwise
  looks broken.
- **The synopsis goes through `wp_kses_post()`, not `esc_html()`.** The sync
  writes plain text, but WordPress allows limited markup in a term description
  and a site owner may well have edited one. Printing their tags back at them
  would be the wrong call. There's a test for it.
- **External links are off by default here.** On a single event they identify
  that episode, which is worth having. On a series archive they mostly repeat
  what the series name already says, so they're opt-in.
- Landscape frame again, since `show_poster` is a 16:9 still.

## Usage

```html
<!-- wp:traktivity/show-header {"align":"wide"} /-->

<!-- Text only, for a compact archive: -->
<!-- wp:traktivity/show-header {"showImage":false,"showSynopsis":false} /-->
```

## Testing

`composer run lint && composer run analyse` clean. PHPUnit 207 passing, 447
assertions. Build, package check and the JS gates all pass.

New coverage: a full header, rendering nothing off a series archive, rendering
nothing on another taxonomy's archive, a bare series with only a name, each part
hidden independently, links off by default and available on request, the heading
level configurable and clamped, and a formatted synopsis keeping its markup.

## Where this leaves the milestone

All seven blocks are in. What's left is #697 (templates), #698 (settings), #699
(template parts) and #702 (the season 0 sync bug), none of which add new blocks —
they assemble these into pages and make them findable.
