### PR TITLE
Provide default block templates for events, archives and series

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "files": [
     "assets",
     "build",
+    "templates",
     "widgets",
     "admin.traktivity.php",
     "blocks.traktivity.php",

--- a/templates.traktivity.php
+++ b/templates.traktivity.php
@@ -1,14 +1,14 @@
 <?php
 /**
- * Block templates and template parts.
+ * Block templates.
  *
- * Placeholder. The default block templates land here in issue #697 and the
- * editable template parts in #699. Both are off unless switched on from the
- * dashboard; see the Decisions section on issue #683.
+ * Default templates for the post type and taxonomies this plugin registers, so
+ * a synced site looks right in a stock block theme without anyone assembling
+ * blocks by hand.
  *
- * The file exists already, and is wired into Traktivity::load_plugin(), so
- * that work does not have to touch traktivity.php and conflict with the rest
- * of the 3.1.0 milestone.
+ * They are off until switched on from the dashboard. Templates change what a
+ * site looks like, and doing that to an existing site on an update, with no
+ * visible switch anywhere, is not a reasonable default. See issue #683.
  *
  * @package Traktivity
  */
@@ -16,3 +16,212 @@
 declare( strict_types = 1 );
 
 defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
+
+/**
+ * Register the plugin's default block templates.
+ *
+ * @since 3.1.0
+ */
+class Traktivity_Templates {
+
+	/**
+	 * Option holding which templates the site owner has switched on.
+	 *
+	 * A single array keyed by template slug, so the settings screen reads and
+	 * writes one option rather than one per template.
+	 *
+	 * @var string
+	 */
+	const OPTION = 'traktivity_templates';
+
+	/**
+	 * Hook everything up.
+	 *
+	 * @since 3.1.0
+	 */
+	public static function init(): void {
+		add_action( 'init', array( __CLASS__, 'register_templates' ), 20 );
+		add_action( 'pre_get_posts', array( __CLASS__, 'order_show_archive' ) );
+	}
+
+	/**
+	 * The templates this plugin can provide.
+	 *
+	 * Keyed by template slug. `file` is the markup to use, which several
+	 * taxonomies share, and `title` and `description` are what the Site Editor
+	 * shows in its template list.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @return array<string, array{file: string, title: string, description: string}>
+	 */
+	public static function available(): array {
+		$shared = __( 'Traktivity archive', 'traktivity' );
+
+		$templates = array(
+			'single-traktivity_event'  => array(
+				'file'        => 'single-traktivity_event.html',
+				'title'       => __( 'Single watch entry', 'traktivity' ),
+				'description' => __( 'One thing you watched, with its series, episode numbers and links out.', 'traktivity' ),
+			),
+			'archive-traktivity_event' => array(
+				'file'        => 'archive-traktivity_event.html',
+				'title'       => __( 'Everything watched', 'traktivity' ),
+				'description' => __( 'The full archive of what you have watched.', 'traktivity' ),
+			),
+			'taxonomy-trakt_show'      => array(
+				'file'        => 'taxonomy-trakt_show.html',
+				'title'       => __( 'One series', 'traktivity' ),
+				'description' => __( 'Every episode logged for one series, oldest first.', 'traktivity' ),
+			),
+		);
+
+		/*
+		 * Genre, year and type archives all want the same layout, so they share
+		 * one file rather than carrying three near-identical copies. They are
+		 * registered separately because the template hierarchy asks for a slug
+		 * per taxonomy, and a bare `taxonomy` template would apply to a site's
+		 * categories and tags too.
+		 */
+		$generic = array(
+			'taxonomy-trakt_genre' => __( 'Genre', 'traktivity' ),
+			'taxonomy-trakt_year'  => __( 'Release year', 'traktivity' ),
+			'taxonomy-trakt_type'  => __( 'Type', 'traktivity' ),
+		);
+
+		foreach ( $generic as $slug => $label ) {
+			$templates[ $slug ] = array(
+				'file'        => 'taxonomy-traktivity.html',
+				/* translators: %s: name of the taxonomy, e.g. Genre. */
+				'title'       => sprintf( __( 'Watch entries by %s', 'traktivity' ), $label ),
+				'description' => $shared,
+			);
+		}
+
+		return $templates;
+	}
+
+	/**
+	 * Whether a template is switched on.
+	 *
+	 * Off unless the option says otherwise, on updates and fresh installs
+	 * alike.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param string $slug Template slug.
+	 *
+	 * @return bool
+	 */
+	public static function is_enabled( string $slug ): bool {
+		$enabled = get_option( self::OPTION );
+
+		return is_array( $enabled ) && ! empty( $enabled[ $slug ] );
+	}
+
+	/**
+	 * Read one template's markup, with its strings translated.
+	 *
+	 * The markup lives in .html files so it can be edited and diffed like
+	 * markup rather than buried in a heredoc. Anything a reader sees is a
+	 * placeholder here and goes through __() on the way out.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param string $file File name under templates/.
+	 *
+	 * @return string Block markup, or an empty string when unreadable.
+	 */
+	public static function content( string $file ): string {
+		$path = TRAKTIVITY__PLUGIN_DIR . 'templates/' . basename( $file );
+
+		if ( ! is_readable( $path ) ) {
+			return '';
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local file bundled with the plugin.
+		$markup = (string) file_get_contents( $path );
+
+		return strtr(
+			$markup,
+			array(
+				'{{ARCHIVE_TITLE}}' => esc_html__( 'Everything watched', 'traktivity' ),
+				'{{NO_RESULTS}}'    => esc_html__( 'Nothing logged here yet.', 'traktivity' ),
+			)
+		);
+	}
+
+	/**
+	 * Register the templates the site owner has switched on.
+	 *
+	 * @since 3.1.0
+	 */
+	public static function register_templates(): void {
+		// The registry is only consulted by block themes, so there is nothing to do otherwise.
+		if ( ! wp_is_block_theme() ) {
+			return;
+		}
+
+		foreach ( self::available() as $slug => $template ) {
+			if ( ! self::is_enabled( $slug ) ) {
+				continue;
+			}
+
+			$content = self::content( $template['file'] );
+
+			/*
+			 * An empty template would render a blank page where the theme's own
+			 * would have rendered something, so a missing file means falling
+			 * through to the theme rather than registering nothing.
+			 */
+			if ( '' === $content ) {
+				continue;
+			}
+
+			register_block_template(
+				'traktivity//' . $slug,
+				array(
+					'title'       => $template['title'],
+					'description' => $template['description'],
+					'content'     => $content,
+				)
+			);
+		}
+	}
+
+	/**
+	 * Read a single series' archive oldest first.
+	 *
+	 * A series is a run, watched in order, so newest-first is simply the wrong
+	 * way round for it. Only applied while our own series template is in use,
+	 * since a theme's template is entitled to its own ordering.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param WP_Query $query The query about to run.
+	 */
+	public static function order_show_archive( $query ): void {
+		if (
+			! $query instanceof WP_Query
+			|| is_admin()
+			|| ! $query->is_main_query()
+			|| ! $query->is_tax( 'trakt_show' )
+			|| ! self::is_enabled( 'taxonomy-trakt_show' )
+		) {
+			return;
+		}
+
+		/**
+		 * Filter the order a single series' archive reads in.
+		 *
+		 * @since 3.1.0
+		 *
+		 * @param string $order Either ASC or DESC. Defaults to ASC.
+		 */
+		$order = (string) apply_filters( 'traktivity_show_archive_order', 'ASC' );
+
+		$query->set( 'order', 'DESC' === strtoupper( $order ) ? 'DESC' : 'ASC' );
+	}
+}
+
+Traktivity_Templates::init();

--- a/templates/archive-traktivity_event.html
+++ b/templates/archive-traktivity_event.html
@@ -1,0 +1,33 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+	<!-- wp:heading {"level":1} -->
+	<h1 class="wp-block-heading">{{ARCHIVE_TITLE}}</h1>
+	<!-- /wp:heading -->
+
+	<!-- wp:traktivity/watch-stats {"align":"wide"} /-->
+
+	<!-- wp:query {"queryId":1,"query":{"perPage":24,"pages":0,"offset":0,"postType":"traktivity_event","order":"desc","orderBy":"date","inherit":true},"align":"wide","layout":{"type":"default"}} -->
+	<div class="wp-block-query alignwide">
+		<!-- wp:post-template {"layout":{"type":"grid","columnCount":4}} -->
+			<!-- wp:traktivity/event-card /-->
+		<!-- /wp:post-template -->
+
+		<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"space-between"}} -->
+			<!-- wp:query-pagination-previous /-->
+			<!-- wp:query-pagination-numbers /-->
+			<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination -->
+
+		<!-- wp:query-no-results -->
+			<!-- wp:paragraph -->
+			<p>{{NO_RESULTS}}</p>
+			<!-- /wp:paragraph -->
+		<!-- /wp:query-no-results -->
+	</div>
+	<!-- /wp:query -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/templates/single-traktivity_event.html
+++ b/templates/single-traktivity_event.html
@@ -1,0 +1,17 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+	<!-- wp:traktivity/event-title {"level":1} /-->
+
+	<!-- wp:post-date {"fontSize":"small"} /-->
+
+	<!-- wp:post-featured-image /-->
+
+	<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
+
+	<!-- wp:traktivity/event-details /-->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/templates/taxonomy-trakt_show.html
+++ b/templates/taxonomy-trakt_show.html
@@ -1,0 +1,23 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+	<!-- wp:traktivity/show-header {"align":"wide"} /-->
+
+	<!-- wp:query {"queryId":2,"query":{"perPage":48,"pages":0,"offset":0,"postType":"traktivity_event","order":"asc","orderBy":"date","inherit":true},"align":"wide","layout":{"type":"default"}} -->
+	<div class="wp-block-query alignwide">
+		<!-- wp:post-template {"layout":{"type":"grid","columnCount":4}} -->
+			<!-- wp:traktivity/event-card /-->
+		<!-- /wp:post-template -->
+
+		<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"space-between"}} -->
+			<!-- wp:query-pagination-previous /-->
+			<!-- wp:query-pagination-numbers /-->
+			<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination -->
+	</div>
+	<!-- /wp:query -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/templates/taxonomy-traktivity.html
+++ b/templates/taxonomy-traktivity.html
@@ -1,0 +1,31 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+	<!-- wp:query-title {"type":"archive","showPrefix":false,"level":1} /-->
+
+	<!-- wp:term-description /-->
+
+	<!-- wp:query {"queryId":3,"query":{"perPage":24,"pages":0,"offset":0,"postType":"traktivity_event","order":"desc","orderBy":"date","inherit":true},"align":"wide","layout":{"type":"default"}} -->
+	<div class="wp-block-query alignwide">
+		<!-- wp:post-template {"layout":{"type":"grid","columnCount":4}} -->
+			<!-- wp:traktivity/event-card /-->
+		<!-- /wp:post-template -->
+
+		<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"space-between"}} -->
+			<!-- wp:query-pagination-previous /-->
+			<!-- wp:query-pagination-numbers /-->
+			<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination -->
+
+		<!-- wp:query-no-results -->
+			<!-- wp:paragraph -->
+			<p>{{NO_RESULTS}}</p>
+			<!-- /wp:paragraph -->
+		<!-- /wp:query-no-results -->
+	</div>
+	<!-- /wp:query -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/tests/package/verify-package.mjs
+++ b/tests/package/verify-package.mjs
@@ -53,6 +53,7 @@ const allowed = [
 	/^widgets\/[^/]+\.php$/,
 	/^build\//,
 	/^assets\/[^/]+\.css$/,
+	/^templates\/[^/]+\.html$/,
 	/^readme\.txt$/,
 	/^LICENSE\.md$/,
 ];
@@ -116,6 +117,10 @@ for ( const required of [
 	'build/blocks/latest-watch/render.php',
 	'build/blocks/show-header/block.json',
 	'build/blocks/show-header/render.php',
+	'templates/single-traktivity_event.html',
+	'templates/archive-traktivity_event.html',
+	'templates/taxonomy-trakt_show.html',
+	'templates/taxonomy-traktivity.html',
 ] ) {
 	check( has( required ), `ships ${ required }` );
 }

--- a/tests/php/BlockTemplatesTest.php
+++ b/tests/php/BlockTemplatesTest.php
@@ -1,0 +1,284 @@
+<?php
+/**
+ * Tests for the default block templates.
+ *
+ * @package Traktivity
+ */
+
+/**
+ * Providing templates for the post type and taxonomies the plugin registers.
+ */
+class BlockTemplatesTest extends WP_UnitTestCase {
+
+	/**
+	 * Start each test with nothing switched on.
+	 */
+	public function set_up() {
+		parent::set_up();
+		delete_option( Traktivity_Templates::OPTION );
+	}
+
+	/**
+	 * Switch templates on.
+	 *
+	 * @param string[] $slugs Template slugs to enable.
+	 */
+	private function enable( array $slugs ) {
+		update_option( Traktivity_Templates::OPTION, array_fill_keys( $slugs, true ) );
+	}
+
+	/**
+	 * Stand up a query that looks like a series archive.
+	 *
+	 * WP_Query::is_tax() reads both $this->is_tax and the queried object, and a
+	 * bare WP_Query has neither until a real request has been parsed, so both
+	 * are staged here the way WordPress would set them.
+	 *
+	 * @param string $slug Series slug.
+	 *
+	 * @return WP_Query
+	 */
+	private function series_archive_query( $slug ) {
+		$term = self::factory()->term->create_and_get(
+			array(
+				'taxonomy' => 'trakt_show',
+				'name'     => ucwords( str_replace( '-', ' ', $slug ) ),
+				'slug'     => $slug,
+			)
+		);
+
+		$query                    = new WP_Query();
+		$query->is_tax            = true;
+		$query->is_archive        = true;
+		$query->queried_object    = $term;
+		$query->queried_object_id = $term->term_id;
+
+		return $query;
+	}
+
+	/**
+	 * Every advertised template points at markup that exists and parses.
+	 *
+	 * @dataProvider data_templates
+	 *
+	 * @param string $slug     Template slug.
+	 * @param array  $template Template definition.
+	 */
+	public function test_template_markup_is_usable( $slug, $template ) {
+		$content = Traktivity_Templates::content( $template['file'] );
+
+		$this->assertNotSame( '', $content, "{$slug} has no markup." );
+		$this->assertStringContainsString( '<!-- wp:', $content, "{$slug} does not look like block markup." );
+		$this->assertStringNotContainsString( '{{', $content, "{$slug} still carries an unsubstituted placeholder." );
+	}
+
+	/**
+	 * Each template the plugin can provide.
+	 *
+	 * @return array<string, array{string, array}>
+	 */
+	public function data_templates() {
+		$cases = array();
+
+		foreach ( Traktivity_Templates::available() as $slug => $template ) {
+			$cases[ $slug ] = array( $slug, $template );
+		}
+
+		return $cases;
+	}
+
+	/**
+	 * Templates reference only blocks that exist.
+	 *
+	 * A template naming a block that was renamed or never registered shows a
+	 * block error on the front end rather than failing loudly, so it is worth
+	 * checking here.
+	 *
+	 * @dataProvider data_templates
+	 *
+	 * @param string $slug     Template slug.
+	 * @param array  $template Template definition.
+	 */
+	public function test_templates_only_use_traktivity_blocks_that_exist( $slug, $template ) {
+		$content  = Traktivity_Templates::content( $template['file'] );
+		$registry = WP_Block_Type_Registry::get_instance();
+
+		preg_match_all( '/<!-- wp:(traktivity\/[a-z-]+)/', $content, $matches );
+
+		foreach ( array_unique( $matches[1] ) as $block ) {
+			$built = TRAKTIVITY__PLUGIN_DIR . 'build/blocks/' . str_replace( 'traktivity/', '', $block );
+
+			if ( ! $registry->is_registered( $block ) && is_dir( $built ) ) {
+				register_block_type( $built );
+			}
+
+			$this->assertTrue( $registry->is_registered( $block ), "{$slug} references {$block}, which is not registered." );
+		}
+	}
+
+	/**
+	 * Nothing is switched on by default.
+	 *
+	 * An update must not reshape an existing site without being asked.
+	 */
+	public function test_nothing_is_enabled_by_default() {
+		foreach ( array_keys( Traktivity_Templates::available() ) as $slug ) {
+			$this->assertFalse( Traktivity_Templates::is_enabled( $slug ), "{$slug} is on by default." );
+		}
+	}
+
+	/**
+	 * Switching one on leaves the others alone.
+	 */
+	public function test_templates_are_enabled_individually() {
+		$this->enable( array( 'single-traktivity_event' ) );
+
+		$this->assertTrue( Traktivity_Templates::is_enabled( 'single-traktivity_event' ) );
+		$this->assertFalse( Traktivity_Templates::is_enabled( 'archive-traktivity_event' ) );
+	}
+
+	/**
+	 * An enabled template registers, and resolves through the hierarchy.
+	 *
+	 * Needs a block theme active, since the registry is only consulted by one.
+	 * The suite runs under whatever theme wp-env installed, so this switches to
+	 * a bundled block theme for the duration.
+	 */
+	public function test_enabled_template_registers() {
+		$theme = wp_get_theme( 'twentytwentyfour' );
+
+		if ( ! $theme->exists() ) {
+			$this->markTestSkipped( 'No block theme available to switch to.' );
+		}
+
+		$previous = get_stylesheet();
+		switch_theme( 'twentytwentyfour' );
+
+		$this->enable( array( 'single-traktivity_event' ) );
+		Traktivity_Templates::register_templates();
+
+		$registered = get_block_templates( array( 'slug__in' => array( 'single-traktivity_event' ) ) );
+		$slugs      = wp_list_pluck( $registered, 'slug' );
+
+		switch_theme( $previous );
+
+		$this->assertContains( 'single-traktivity_event', $slugs );
+	}
+
+	/**
+	 * A template that is off does not register.
+	 */
+	public function test_disabled_template_does_not_register() {
+		$theme = wp_get_theme( 'twentytwentyfour' );
+
+		if ( ! $theme->exists() ) {
+			$this->markTestSkipped( 'No block theme available to switch to.' );
+		}
+
+		$previous = get_stylesheet();
+		switch_theme( 'twentytwentyfour' );
+
+		Traktivity_Templates::register_templates();
+
+		$registered = get_block_templates( array( 'slug__in' => array( 'archive-traktivity_event' ) ) );
+		$slugs      = wp_list_pluck( $registered, 'slug' );
+
+		switch_theme( $previous );
+
+		$this->assertNotContains( 'archive-traktivity_event', $slugs );
+	}
+
+	/**
+	 * Nothing registers on a classic theme.
+	 *
+	 * The registry is only consulted by block themes, so registering into it
+	 * would be noise.
+	 */
+	public function test_nothing_registers_on_a_classic_theme() {
+		if ( ! class_exists( 'WP_Block_Templates_Registry' ) ) {
+			$this->markTestSkipped( 'Needs the block template registry.' );
+		}
+
+		$registry = WP_Block_Templates_Registry::get_instance();
+		$name     = 'traktivity//archive-traktivity_event';
+
+		if ( $registry->is_registered( $name ) ) {
+			unregister_block_template( $name );
+		}
+
+		$this->enable( array( 'archive-traktivity_event' ) );
+
+		add_filter( 'wp_is_block_theme', '__return_false' );
+		Traktivity_Templates::register_templates();
+		remove_filter( 'wp_is_block_theme', '__return_false' );
+
+		$this->assertFalse( $registry->is_registered( $name ) );
+	}
+
+	/**
+	 * An unreadable file falls through rather than registering a blank page.
+	 */
+	public function test_missing_file_yields_no_content() {
+		$this->assertSame( '', Traktivity_Templates::content( 'does-not-exist.html' ) );
+	}
+
+	/**
+	 * The file name cannot escape the templates directory.
+	 */
+	public function test_file_names_cannot_traverse() {
+		$this->assertSame( '', Traktivity_Templates::content( '../../wp-config.php' ) );
+	}
+
+	/**
+	 * A series archive reads oldest first while our template is in use.
+	 *
+	 * A series is a run watched in order, so newest-first is the wrong way
+	 * round for it.
+	 */
+	public function test_series_archive_reads_oldest_first() {
+		$this->enable( array( 'taxonomy-trakt_show' ) );
+
+		$query    = $this->series_archive_query( 'some-series' );
+		$previous = $GLOBALS['wp_the_query'];
+
+		$GLOBALS['wp_the_query'] = $query;
+		Traktivity_Templates::order_show_archive( $query );
+		$GLOBALS['wp_the_query'] = $previous;
+
+		$this->assertSame( 'ASC', $query->get( 'order' ) );
+	}
+
+	/**
+	 * The ordering is left alone when our template is not in use.
+	 */
+	public function test_ordering_is_untouched_when_the_template_is_off() {
+		$query    = $this->series_archive_query( 'another-series' );
+		$previous = $GLOBALS['wp_the_query'];
+
+		$GLOBALS['wp_the_query'] = $query;
+		Traktivity_Templates::order_show_archive( $query );
+		$GLOBALS['wp_the_query'] = $previous;
+
+		$this->assertSame( '', $query->get( 'order' ) );
+	}
+
+	/**
+	 * Every template carries a translatable title and description.
+	 *
+	 * They are the only signpost in the Site Editor's template list.
+	 */
+	public function test_templates_are_described() {
+		foreach ( Traktivity_Templates::available() as $slug => $template ) {
+			$this->assertNotSame( '', $template['title'], "{$slug} has no title." );
+			$this->assertNotSame( '', $template['description'], "{$slug} has no description." );
+		}
+	}
+
+	/**
+	 * Registration is wired to init.
+	 */
+	public function test_registration_is_hooked() {
+		$this->assertNotFalse( has_action( 'init', array( 'Traktivity_Templates', 'register_templates' ) ) );
+		$this->assertNotFalse( has_action( 'pre_get_posts', array( 'Traktivity_Templates', 'order_show_archive' ) ) );
+	}
+}


### PR DESCRIPTION
Fixes #697

## What it does

Six default block templates, built from the blocks this milestone added:

| Slug | |
|---|---|
| `single-traktivity_event` | Title, date, image, content, details |
| `archive-traktivity_event` | Stats band, then a grid of Event Cards |
| `taxonomy-trakt_show` | Series Header, then that series' episodes |
| `taxonomy-trakt_genre` / `trakt_year` / `trakt_type` | A shared archive layout |

All off until switched on.

## Rationale

With every block shipped, a site owner still had to assemble them by hand: open
the Site Editor, create a template for the post type, work out that a Query Loop
needs an Event Card inside its Post Template, repeat for the archive and the
series taxonomy. Out of the box a synced site showed archives full of bare
episode names.

Decisions worth flagging:

- **Six templates, four files.** Genre, year and type archives want the same
  layout, so they share one file rather than three near-identical copies. They're
  registered per taxonomy because the hierarchy asks for a slug per taxonomy, and
  a bare `taxonomy` template would apply to a site's own categories and tags too.
- **Markup lives in `.html` files**, not PHP heredocs, so it can be edited and
  diffed as markup — and so #699 can read the same files. Reader-facing strings
  are placeholders substituted at registration, so they go through `__()` rather
  than shipping untranslated inside the HTML.
- **Off for everyone**, on updates and fresh installs alike, per the decision on
  #683. That makes #698 the only route to discovering any of this, so the two have
  to ship together.
- **No `function_exists()` guard.** The plugin requires WordPress 7.0 and
  `register_block_template()` landed in 6.7, so the guard I'd originally written
  into the issue was dead code.
- **A series archive reads oldest first.** A series is a run, watched in order,
  and newest-first is the wrong way round for it. Only applied while our own
  series template is in use, since a theme's template is entitled to its own
  ordering, and filterable either way via `traktivity_show_archive_order`.
- Content is read through `basename()`, so a file name can't walk out of the
  templates directory, and an unreadable file falls through to the theme rather
  than registering a blank page.

## Testing

`composer run lint && composer run analyse` clean. PHPUnit 235 passing, 508
assertions. Build and package check pass.

Two tests are worth pointing at. One switches to a bundled block theme and
asserts the template actually resolves through `get_block_templates()`, rather
than skipping when the suite's own theme is classic. Another asserts that every
`traktivity/*` block a template references is registered — a template naming a
renamed block shows a block error on the front end rather than failing loudly, so
it's worth catching here.

Also covered: markup existing and carrying no unsubstituted placeholders, nothing
enabled by default, templates enabled individually, a disabled template not
registering, nothing registering on a classic theme, a missing file yielding no
content, path traversal being blocked, the series ordering applied and not
applied, and every template carrying a title and description.

## What's left

#698 makes these findable, and #699 adds the editable parts.
