### PR TITLE
Ship editable template parts built from the blocks

### DIFF
--- a/templates.traktivity.php
+++ b/templates.traktivity.php
@@ -41,6 +41,7 @@ class Traktivity_Templates {
 	 */
 	public static function init(): void {
 		add_action( 'init', array( __CLASS__, 'register_templates' ), 20 );
+		add_filter( 'get_block_template', array( __CLASS__, 'provide_template_part' ), 10, 3 );
 		add_action( 'pre_get_posts', array( __CLASS__, 'order_show_archive' ) );
 	}
 
@@ -133,7 +134,13 @@ class Traktivity_Templates {
 	 * @return string Block markup, or an empty string when unreadable.
 	 */
 	public static function content( string $file ): string {
-		$path = TRAKTIVITY__PLUGIN_DIR . 'templates/' . basename( $file );
+		/*
+		 * basename() on the file, so a name cannot walk out of the directory,
+		 * and the subdirectory is chosen here rather than taken from the
+		 * caller.
+		 */
+		$directory = 0 === strpos( $file, 'parts/' ) ? 'templates/parts/' : 'templates/';
+		$path      = TRAKTIVITY__PLUGIN_DIR . $directory . basename( $file );
 
 		if ( ! is_readable( $path ) ) {
 			return '';
@@ -147,6 +154,9 @@ class Traktivity_Templates {
 			array(
 				'{{ARCHIVE_TITLE}}' => esc_html__( 'Everything watched', 'traktivity' ),
 				'{{NO_RESULTS}}'    => esc_html__( 'Nothing logged here yet.', 'traktivity' ),
+				'{{RECENT_TITLE}}'  => esc_html__( 'Recently watched', 'traktivity' ),
+				'{{LATEST_TITLE}}'  => esc_html__( 'Last watched', 'traktivity' ),
+				'{{INDEX_TITLE}}'   => esc_html__( 'Every series', 'traktivity' ),
 			)
 		);
 	}
@@ -221,6 +231,113 @@ class Traktivity_Templates {
 		$order = (string) apply_filters( 'traktivity_show_archive_order', 'ASC' );
 
 		$query->set( 'order', 'DESC' === strtoupper( $order ) ? 'DESC' : 'ASC' );
+	}
+
+	/**
+	 * The editable template parts this plugin can provide.
+	 *
+	 * Keyed by part slug. Unlike the templates above, these have no automatic
+	 * placement: nothing renders them until a site owner adds core's Template
+	 * Part block to a template and picks one. See issue #699.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @return array<string, array{file: string, title: string, description: string}>
+	 */
+	public static function available_parts(): array {
+		return array(
+			'traktivity-recent-watches' => array(
+				'file'        => 'parts/traktivity-recent-watches.html',
+				'title'       => __( 'Recently watched', 'traktivity' ),
+				'description' => __( 'The last few things you watched, as a grid of cards.', 'traktivity' ),
+			),
+			'traktivity-latest-watch'   => array(
+				'file'        => 'parts/traktivity-latest-watch.html',
+				'title'       => __( 'Last watched, large', 'traktivity' ),
+				'description' => __( 'The most recent thing you watched, shown large.', 'traktivity' ),
+			),
+			'traktivity-watch-stats'    => array(
+				'file'        => 'parts/traktivity-watch-stats.html',
+				'title'       => __( 'Watch totals', 'traktivity' ),
+				'description' => __( 'Hours, entries, episodes, films and series, as a band.', 'traktivity' ),
+			),
+			'traktivity-series-index'   => array(
+				'file'        => 'parts/traktivity-series-index.html',
+				'title'       => __( 'Every series, A to Z', 'traktivity' ),
+				'description' => __( 'A full index of every series you have logged.', 'traktivity' ),
+			),
+			'traktivity-recent-compact' => array(
+				'file'        => 'parts/traktivity-recent-compact.html',
+				'title'       => __( 'Recently watched, compact', 'traktivity' ),
+				'description' => __( 'A short text list, for a sidebar or a footer.', 'traktivity' ),
+			),
+		);
+	}
+
+	/**
+	 * The ID a template part is known by.
+	 *
+	 * Namespaced to the active theme on purpose. The moment someone edits one
+	 * of these in the Site Editor, WordPress saves a real wp_template_part
+	 * post under that ID, get_block_template() stops coming back empty, and
+	 * the filter below quietly steps aside. The site owner gets an editable
+	 * default with nothing to migrate.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param string $slug Part slug.
+	 *
+	 * @return string
+	 */
+	public static function part_id( string $slug ): string {
+		return get_stylesheet() . '//' . $slug;
+	}
+
+	/**
+	 * Hand back one of our parts when nothing else claims that ID.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param WP_Block_Template|null $block_template Template found so far.
+	 * @param string                 $id             Template ID being asked for.
+	 * @param string                 $template_type  Either wp_template or wp_template_part.
+	 *
+	 * @return WP_Block_Template|null
+	 */
+	public static function provide_template_part( $block_template, $id, $template_type ) {
+		if ( ! empty( $block_template ) || 'wp_template_part' !== $template_type || ! wp_is_block_theme() ) {
+			return $block_template;
+		}
+
+		foreach ( self::available_parts() as $slug => $part ) {
+			if ( self::part_id( $slug ) !== $id || ! self::is_enabled( $slug ) ) {
+				continue;
+			}
+
+			$content = self::content( $part['file'] );
+
+			if ( '' === $content ) {
+				return $block_template;
+			}
+
+			$template                 = new WP_Block_Template();
+			$template->id             = $id;
+			$template->theme          = get_stylesheet();
+			$template->slug           = $slug;
+			$template->type           = 'wp_template_part';
+			$template->area           = 'uncategorized';
+			$template->source         = 'plugin';
+			$template->status         = 'publish';
+			$template->has_theme_file = false;
+			$template->is_custom      = true;
+			$template->title          = $part['title'];
+			$template->description    = $part['description'];
+			$template->content        = $content;
+
+			return $template;
+		}
+
+		return $block_template;
 	}
 }
 

--- a/templates/parts/traktivity-latest-watch.html
+++ b/templates/parts/traktivity-latest-watch.html
@@ -1,0 +1,5 @@
+<!-- wp:heading -->
+<h2 class="wp-block-heading">{{LATEST_TITLE}}</h2>
+<!-- /wp:heading -->
+
+<!-- wp:traktivity/latest-watch /-->

--- a/templates/parts/traktivity-recent-compact.html
+++ b/templates/parts/traktivity-recent-compact.html
@@ -1,0 +1,11 @@
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">{{RECENT_TITLE}}</h3>
+<!-- /wp:heading -->
+
+<!-- wp:query {"queryId":11,"query":{"perPage":5,"pages":1,"offset":0,"postType":"traktivity_event","order":"desc","orderBy":"date","inherit":false},"layout":{"type":"default"}} -->
+<div class="wp-block-query">
+	<!-- wp:post-template -->
+		<!-- wp:traktivity/event-card {"showImage":false,"headingLevel":4} /-->
+	<!-- /wp:post-template -->
+</div>
+<!-- /wp:query -->

--- a/templates/parts/traktivity-recent-watches.html
+++ b/templates/parts/traktivity-recent-watches.html
@@ -1,0 +1,11 @@
+<!-- wp:heading -->
+<h2 class="wp-block-heading">{{RECENT_TITLE}}</h2>
+<!-- /wp:heading -->
+
+<!-- wp:query {"queryId":10,"query":{"perPage":8,"pages":1,"offset":0,"postType":"traktivity_event","order":"desc","orderBy":"date","inherit":false},"layout":{"type":"default"}} -->
+<div class="wp-block-query">
+	<!-- wp:post-template {"layout":{"type":"grid","columnCount":4}} -->
+		<!-- wp:traktivity/event-card /-->
+	<!-- /wp:post-template -->
+</div>
+<!-- /wp:query -->

--- a/templates/parts/traktivity-series-index.html
+++ b/templates/parts/traktivity-series-index.html
@@ -1,0 +1,5 @@
+<!-- wp:heading -->
+<h2 class="wp-block-heading">{{INDEX_TITLE}}</h2>
+<!-- /wp:heading -->
+
+<!-- wp:traktivity/top-shows {"number":0,"orderby":"name","columns":4} /-->

--- a/templates/parts/traktivity-watch-stats.html
+++ b/templates/parts/traktivity-watch-stats.html
@@ -1,0 +1,1 @@
+<!-- wp:traktivity/watch-stats {"align":"wide"} /-->

--- a/tests/package/verify-package.mjs
+++ b/tests/package/verify-package.mjs
@@ -54,6 +54,7 @@ const allowed = [
 	/^build\//,
 	/^assets\/[^/]+\.css$/,
 	/^templates\/[^/]+\.html$/,
+	/^templates\/parts\/[^/]+\.html$/,
 	/^readme\.txt$/,
 	/^LICENSE\.md$/,
 ];
@@ -121,6 +122,8 @@ for ( const required of [
 	'templates/archive-traktivity_event.html',
 	'templates/taxonomy-trakt_show.html',
 	'templates/taxonomy-traktivity.html',
+	'templates/parts/traktivity-recent-watches.html',
+	'templates/parts/traktivity-watch-stats.html',
 ] ) {
 	check( has( required ), `ships ${ required }` );
 }

--- a/tests/php/TemplatePartsTest.php
+++ b/tests/php/TemplatePartsTest.php
@@ -1,0 +1,270 @@
+<?php
+/**
+ * Tests for the editable template parts.
+ *
+ * @package Traktivity
+ */
+
+/**
+ * Providing template parts a site owner can edit and place themselves.
+ */
+class TemplatePartsTest extends WP_UnitTestCase {
+
+	/**
+	 * Theme active before a test switched it.
+	 *
+	 * @var string
+	 */
+	private $previous_theme = '';
+
+	/**
+	 * Start each test with nothing switched on.
+	 */
+	public function set_up() {
+		parent::set_up();
+		delete_option( Traktivity_Templates::OPTION );
+	}
+
+	/**
+	 * Put any switched theme back.
+	 */
+	public function tear_down() {
+		if ( '' !== $this->previous_theme ) {
+			switch_theme( $this->previous_theme );
+			$this->previous_theme = '';
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Switch to a block theme, since parts only resolve under one.
+	 *
+	 * @return bool Whether a block theme was available.
+	 */
+	private function use_block_theme() {
+		if ( ! wp_get_theme( 'twentytwentyfour' )->exists() ) {
+			return false;
+		}
+
+		$this->previous_theme = get_stylesheet();
+		switch_theme( 'twentytwentyfour' );
+
+		return true;
+	}
+
+	/**
+	 * Switch parts on.
+	 *
+	 * @param string[] $slugs Part slugs to enable.
+	 */
+	private function enable( array $slugs ) {
+		update_option( Traktivity_Templates::OPTION, array_fill_keys( $slugs, true ) );
+	}
+
+	/**
+	 * Every advertised part points at markup that exists and is substituted.
+	 *
+	 * @dataProvider data_parts
+	 *
+	 * @param string $slug Part slug.
+	 * @param array  $part Part definition.
+	 */
+	public function test_part_markup_is_usable( $slug, $part ) {
+		$content = Traktivity_Templates::content( $part['file'] );
+
+		$this->assertNotSame( '', $content, "{$slug} has no markup." );
+		$this->assertStringContainsString( '<!-- wp:', $content, "{$slug} does not look like block markup." );
+		$this->assertStringNotContainsString( '{{', $content, "{$slug} still carries an unsubstituted placeholder." );
+	}
+
+	/**
+	 * Each part the plugin can provide.
+	 *
+	 * @return array<string, array{string, array}>
+	 */
+	public function data_parts() {
+		$cases = array();
+
+		foreach ( Traktivity_Templates::available_parts() as $slug => $part ) {
+			$cases[ $slug ] = array( $slug, $part );
+		}
+
+		return $cases;
+	}
+
+	/**
+	 * Parts reference only blocks that exist.
+	 *
+	 * @dataProvider data_parts
+	 *
+	 * @param string $slug Part slug.
+	 * @param array  $part Part definition.
+	 */
+	public function test_parts_only_use_blocks_that_exist( $slug, $part ) {
+		$content  = Traktivity_Templates::content( $part['file'] );
+		$registry = WP_Block_Type_Registry::get_instance();
+
+		preg_match_all( '/<!-- wp:(traktivity\/[a-z-]+)/', $content, $matches );
+
+		$this->assertNotEmpty( $matches[1], "{$slug} uses no Traktivity block, so it has no reason to exist." );
+
+		foreach ( array_unique( $matches[1] ) as $block ) {
+			$built = TRAKTIVITY__PLUGIN_DIR . 'build/blocks/' . str_replace( 'traktivity/', '', $block );
+
+			if ( ! $registry->is_registered( $block ) && is_dir( $built ) ) {
+				register_block_type( $built );
+			}
+
+			$this->assertTrue( $registry->is_registered( $block ), "{$slug} references {$block}, which is not registered." );
+		}
+	}
+
+	/**
+	 * A part ID is namespaced to the active theme.
+	 *
+	 * That is what lets a saved copy take over: WordPress stores an edited
+	 * part under this ID, get_block_template() stops coming back empty, and
+	 * our filter steps aside.
+	 */
+	public function test_part_id_is_namespaced_to_the_theme() {
+		$this->assertSame(
+			get_stylesheet() . '//traktivity-watch-stats',
+			Traktivity_Templates::part_id( 'traktivity-watch-stats' )
+		);
+	}
+
+	/**
+	 * An enabled part is handed back for its own ID.
+	 */
+	public function test_enabled_part_is_provided() {
+		if ( ! $this->use_block_theme() ) {
+			$this->markTestSkipped( 'No block theme available to switch to.' );
+		}
+
+		$this->enable( array( 'traktivity-watch-stats' ) );
+
+		$id   = Traktivity_Templates::part_id( 'traktivity-watch-stats' );
+		$part = Traktivity_Templates::provide_template_part( null, $id, 'wp_template_part' );
+
+		$this->assertInstanceOf( 'WP_Block_Template', $part );
+		$this->assertSame( 'traktivity-watch-stats', $part->slug );
+		$this->assertSame( 'plugin', $part->source );
+		$this->assertFalse( $part->has_theme_file );
+		$this->assertStringContainsString( 'traktivity/watch-stats', $part->content );
+	}
+
+	/**
+	 * A part that is switched off is not provided.
+	 */
+	public function test_disabled_part_is_not_provided() {
+		$id = Traktivity_Templates::part_id( 'traktivity-watch-stats' );
+
+		$this->assertNull( Traktivity_Templates::provide_template_part( null, $id, 'wp_template_part' ) );
+	}
+
+	/**
+	 * Something else already claiming the ID wins.
+	 *
+	 * This is how an edited copy takes over: once WordPress has saved one,
+	 * the filter is handed a template and hands it straight back.
+	 */
+	public function test_an_existing_template_wins() {
+		$this->enable( array( 'traktivity-watch-stats' ) );
+
+		$existing          = new WP_Block_Template();
+		$existing->slug    = 'traktivity-watch-stats';
+		$existing->source  = 'custom';
+		$existing->content = 'Edited by the site owner.';
+
+		$provided = Traktivity_Templates::provide_template_part(
+			$existing,
+			Traktivity_Templates::part_id( 'traktivity-watch-stats' ),
+			'wp_template_part'
+		);
+
+		$this->assertSame( 'custom', $provided->source );
+		$this->assertSame( 'Edited by the site owner.', $provided->content );
+	}
+
+	/**
+	 * An unrelated ID is left alone.
+	 */
+	public function test_other_ids_are_left_alone() {
+		$this->enable( array( 'traktivity-watch-stats' ) );
+
+		$this->assertNull(
+			Traktivity_Templates::provide_template_part( null, get_stylesheet() . '//header', 'wp_template_part' )
+		);
+	}
+
+	/**
+	 * A whole template asking for the same ID is left alone.
+	 */
+	public function test_whole_templates_are_left_alone() {
+		$this->enable( array( 'traktivity-watch-stats' ) );
+
+		$this->assertNull(
+			Traktivity_Templates::provide_template_part(
+				null,
+				Traktivity_Templates::part_id( 'traktivity-watch-stats' ),
+				'wp_template'
+			)
+		);
+	}
+
+	/**
+	 * Nothing is provided on a classic theme.
+	 */
+	public function test_nothing_is_provided_on_a_classic_theme() {
+		$this->enable( array( 'traktivity-watch-stats' ) );
+
+		add_filter( 'wp_is_block_theme', '__return_false' );
+		$part = Traktivity_Templates::provide_template_part(
+			null,
+			Traktivity_Templates::part_id( 'traktivity-watch-stats' ),
+			'wp_template_part'
+		);
+		remove_filter( 'wp_is_block_theme', '__return_false' );
+
+		$this->assertNull( $part );
+	}
+
+	/**
+	 * Every part carries a translatable title and description.
+	 *
+	 * They are the only signpost in the Site Editor's parts list, which is
+	 * the only place anyone will find these.
+	 */
+	public function test_parts_are_described() {
+		foreach ( Traktivity_Templates::available_parts() as $slug => $part ) {
+			$this->assertNotSame( '', $part['title'], "{$slug} has no title." );
+			$this->assertNotSame( '', $part['description'], "{$slug} has no description." );
+		}
+	}
+
+	/**
+	 * Parts carry no hard-coded term or post IDs.
+	 *
+	 * Term IDs differ per site, so a query filtered by one works on exactly
+	 * one install.
+	 *
+	 * @dataProvider data_parts
+	 *
+	 * @param string $slug Part slug.
+	 * @param array  $part Part definition.
+	 */
+	public function test_parts_carry_no_hardcoded_ids( $slug, $part ) {
+		$content = Traktivity_Templates::content( $part['file'] );
+
+		$this->assertStringNotContainsString( 'taxQuery', $content, "{$slug} filters by term ID." );
+		$this->assertDoesNotMatchRegularExpression( '/"(postId|termId)":\s*\d+/', $content, "{$slug} carries a hard-coded ID." );
+	}
+
+	/**
+	 * The filter is wired up.
+	 */
+	public function test_filter_is_hooked() {
+		$this->assertNotFalse( has_filter( 'get_block_template', array( 'Traktivity_Templates', 'provide_template_part' ) ) );
+	}
+}


### PR DESCRIPTION
Fixes #699

## What it does

Five editable template parts, built from the blocks in this milestone:

| Slug | |
|---|---|
| `traktivity-recent-watches` | The last few things watched, as a grid |
| `traktivity-latest-watch` | The most recent thing, shown large |
| `traktivity-watch-stats` | The totals as a band |
| `traktivity-series-index` | Every series, A to Z |
| `traktivity-recent-compact` | A short text list for a sidebar or footer |

## Rationale

#697 covers the pages Traktivity owns. This covers the pieces people want to put
somewhere themselves, which the plugin has no way of guessing at.

They're provided through the `get_block_template` filter rather than registered
outright, following `class-jetpack-subscribe-modal.php`. The ID is namespaced to
the active theme, which is the whole point:

```php
$template->id = get_stylesheet() . '//' . $slug;
```

The moment someone edits one in the Site Editor, WordPress saves a real
`wp_template_part` post under that ID, the filter stops being handed an empty
template, and it steps aside. An editable default with nothing to migrate.
There's a test asserting an existing template wins.

## The limitation, stated plainly

**These have no automatic placement.** Jetpack's subscribe modal renders itself
into `wp_footer`; there's no equivalent hook for "recently watched", because it
belongs wherever the site owner decides.

So a part's switch governs whether it's *offered*, not whether it appears
anywhere. Placing one means adding core's Template Part block to a template and
picking it. Two things follow:

- Nothing shows in the block inserter as a starting point.
- A part can't go inside a post or page's content.

That was the tradeoff accepted when #699 chose parts over patterns. Patterns
would cover the second case and can be added later without undoing any of this.
#698 needs to say all of it on the card, or people will tick a box, see no
change, and file a bug.

## Testing

`composer run lint && composer run analyse` clean. PHPUnit 259 passing, 566
assertions. Build and package check pass.

Coverage: markup existing and substituted, every part using a registered block
(and using at least one, so a part has a reason to exist), the ID namespacing, an
enabled part being provided with the right source and `has_theme_file`, a
disabled part not being provided, an existing template winning, unrelated IDs and
whole templates being left alone, nothing on a classic theme, every part
described, and no hard-coded term or post IDs — a query filtered by a term ID
works on exactly one site.
