### PR TITLE
Let people find and switch on the templates from the dashboard

### DIFF
--- a/admin.traktivity.php
+++ b/admin.traktivity.php
@@ -136,6 +136,18 @@ function traktivity_dashboard_scripts( $hook ) {
 		 * into "3 days, 4 hours" needs _n() for each unit.
 		 */
 		'totalTimeWatched' => $summary['runtime'],
+
+		/*
+		 * Everything the display section needs. The stylesheet is here because
+		 * a Site Editor link has to name a template by its theme-namespaced ID,
+		 * and the block-theme flag because those links go nowhere useful
+		 * otherwise.
+		 */
+		'templates'        => Traktivity_Templates::for_settings(),
+		'isBlockTheme'     => wp_is_block_theme(),
+		'themeStylesheet'  => get_stylesheet(),
+		'siteEditorUrl'    => admin_url( 'site-editor.php' ),
+		'hasEvents'        => $summary['entries'] > 0,
 	);
 
 	/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "@wordpress/i18n": "^6.27.0",
         "@wordpress/jest-console": "^9.2.0",
         "@wordpress/scripts": "^34.2.0",
-        "@wordpress/server-side-render": "^6.30.0"
+        "@wordpress/server-side-render": "^6.30.0",
+        "@wordpress/url": "^4.54.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@wordpress/i18n": "^6.27.0",
     "@wordpress/jest-console": "^9.2.0",
     "@wordpress/scripts": "^34.2.0",
-    "@wordpress/server-side-render": "^6.30.0"
+    "@wordpress/server-side-render": "^6.30.0",
+    "@wordpress/url": "^4.54.0"
   }
 }

--- a/rest.traktivity.php
+++ b/rest.traktivity.php
@@ -105,6 +105,43 @@ class Traktivity_Api {
 		);
 
 		/**
+		 * Read which block templates and parts are switched on.
+		 *
+		 * @since 3.1.0
+		 */
+		register_rest_route(
+			'traktivity/v1',
+			'/templates',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_templates' ),
+				'permission_callback' => array( $this, 'permissions_check' ),
+			)
+		);
+
+		/**
+		 * Switch block templates and parts on or off.
+		 *
+		 * @since 3.1.0
+		 */
+		register_rest_route(
+			'traktivity/v1',
+			'/templates',
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'post_templates' ),
+				'permission_callback' => array( $this, 'permissions_check' ),
+				'args'                => array(
+					'enabled' => array(
+						'type'        => 'object',
+						'required'    => true,
+						'description' => __( 'Template slugs mapped to whether they are switched on.', 'traktivity' ),
+					),
+				),
+			)
+		);
+
+		/**
 		 * Traktivity Stats Info.
 		 *
 		 * @since 2.2.0
@@ -495,7 +532,63 @@ class Traktivity_Api {
 	}
 
 	/**
-	 * Get stats from the Stats option.
+	 * Read which block templates and parts are switched on.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response $response What the plugin can provide, and its state.
+	 */
+	public function get_templates( $request ) {
+		unset( $request );
+
+		return new WP_REST_Response(
+			array(
+				'templates'       => Traktivity_Templates::for_settings(),
+				'isBlockTheme'    => wp_is_block_theme(),
+				'themeStylesheet' => get_stylesheet(),
+			),
+			200
+		);
+	}
+
+	/**
+	 * Switch block templates and parts on or off.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response $response The stored state.
+	 */
+	public function post_templates( $request ) {
+		$enabled = $request->get_param( 'enabled' );
+
+		if ( ! is_array( $enabled ) ) {
+			return new WP_REST_Response(
+				array(
+					'code'    => 400,
+					'message' => esc_html__( 'The list of templates was not readable.', 'traktivity' ),
+				),
+				400
+			);
+		}
+
+		/*
+		 * Unknown slugs are dropped rather than stored, so a stale key from an
+		 * older version cannot accumulate in the option.
+		 */
+		Traktivity_Templates::save_enabled( $enabled );
+
+		return new WP_REST_Response(
+			array( 'templates' => Traktivity_Templates::for_settings() ),
+			200
+		);
+	}
+
+	/**
+	 * Get Traktivity stats.
 	 *
 	 * @since 2.2.0
 	 *

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -12,6 +12,7 @@ import RecentEvents from './RecentEvents';
 import StatsOverview from './stats/StatsOverview';
 import SyncHistory from './SyncHistory';
 import SyncShowTime from './SyncShowTime';
+import TemplateSettings from './templates/TemplateSettings';
 
 /**
  * Step 5: the dashboard shown once setup is complete.
@@ -90,6 +91,7 @@ export default function Dashboard( { sync, launchSync } ) {
 				</CardBody>
 			</Card>
 			<StatsOverview />
+			<TemplateSettings />
 			<RecentEvents />
 			{ ! historyImported && (
 				<SyncHistory

--- a/src/components/templates/TemplateCard.js
+++ b/src/components/templates/TemplateCard.js
@@ -1,0 +1,100 @@
+/**
+ * WordPress dependencies
+ */
+import { CheckboxControl, ExternalLink } from '@wordpress/components';
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import illustrationFor from './illustrations';
+
+/**
+ * One template or part, as a selectable card.
+ *
+ * The label wraps only the wireframe, so clicking the picture toggles the
+ * checkbox while the title and the edit link sit outside it and do not. The
+ * visible title is borrowed as the checkbox's accessible name rather than
+ * repeated in a hidden label.
+ *
+ * @param {Object}   props          Component props.
+ * @param {Object}   props.template The template or part being offered.
+ * @param {boolean}  props.disabled Whether the checkbox is unavailable.
+ * @param {string}   props.editUrl  Site Editor URL, when there is a useful one.
+ * @param {Function} props.onChange Called with ( slug, next ).
+ * @return {Element} The card.
+ */
+export default function TemplateCard( {
+	template,
+	disabled = false,
+	editUrl = '',
+	onChange,
+} ) {
+	const id = `traktivity-template-${ template.slug }`;
+	const titleId = `${ id }__title`;
+
+	const handleChange = useCallback(
+		( next ) => onChange( template.slug, next ),
+		[ onChange, template.slug ]
+	);
+
+	return (
+		<div className="traktivity-template-card">
+			<label
+				htmlFor={ id }
+				className="traktivity-template-card__surface"
+				data-checked={ template.enabled ? 'true' : 'false' }
+			>
+				{ illustrationFor( template.slug ) }
+			</label>
+
+			<div className="traktivity-template-card__body">
+				<CheckboxControl
+					__nextHasNoMarginBottom
+					id={ id }
+					checked={ template.enabled }
+					disabled={ disabled }
+					onChange={ handleChange }
+					aria-labelledby={ titleId }
+					label=""
+				/>
+				<div>
+					<p
+						id={ titleId }
+						className="traktivity-template-card__title"
+					>
+						{ template.title }
+					</p>
+					<p className="traktivity-template-card__description">
+						{ template.description }
+					</p>
+
+					{ template.themeProvides && (
+						<p className="traktivity-template-card__note">
+							{ __(
+								'Your theme already has a template for this, and its own wins. Switching this on will not change anything.',
+								'traktivity'
+							) }
+						</p>
+					) }
+
+					{ template.type === 'wp_template_part' && (
+						<p className="traktivity-template-card__note">
+							{ __(
+								'Nothing places this for you. Switch it on, then add a Template Part block wherever you want it.',
+								'traktivity'
+							) }
+						</p>
+					) }
+
+					{ editUrl && (
+						<ExternalLink href={ editUrl }>
+							{ __( 'Preview and edit', 'traktivity' ) }
+						</ExternalLink>
+					) }
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/components/templates/TemplateSettings.js
+++ b/src/components/templates/TemplateSettings.js
@@ -1,0 +1,188 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import {
+	Button,
+	Card,
+	CardBody,
+	CardHeader,
+	Notice,
+} from '@wordpress/components';
+import { useCallback, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import settings from '../../settings';
+import TemplateCard from './TemplateCard';
+
+/**
+ * Build the Site Editor URL for one template or part.
+ *
+ * Returns nothing on a classic theme, where the Site Editor has nothing to
+ * show: a link that goes somewhere useless is worse than no link.
+ *
+ * @param {Object} template The template or part.
+ * @return {string} The URL, or an empty string.
+ */
+function editUrlFor( template ) {
+	if ( ! settings.isBlockTheme || ! settings.themeStylesheet ) {
+		return '';
+	}
+
+	return addQueryArgs( settings.siteEditorUrl, {
+		postType: template.type,
+		postId: `${ settings.themeStylesheet }//${ template.slug }`,
+		canvas: 'edit',
+	} );
+}
+
+/**
+ * Choose which templates and parts Traktivity provides.
+ *
+ * Everything is off until someone switches it on, which makes this section the
+ * only way anyone finds out these exist. So it explains what each one is and
+ * links straight into the Site Editor rather than leaving people to hunt.
+ *
+ * @return {Element} The section.
+ */
+export default function TemplateSettings() {
+	const [ templates, setTemplates ] = useState(
+		() => settings.templates || []
+	);
+	const [ saving, setSaving ] = useState( false );
+	const [ notice, setNotice ] = useState( null );
+
+	/*
+	 * The edit link follows what has been saved, not what is on screen. Link
+	 * off the optimistic value and someone ticks a box, clicks straight
+	 * through, and lands on a template that was never registered.
+	 */
+	const [ saved, setSaved ] = useState( () => settings.templates || [] );
+
+	const toggle = useCallback(
+		( slug, next ) => {
+			const updated = templates.map( ( template ) =>
+				template.slug === slug
+					? { ...template, enabled: next }
+					: template
+			);
+
+			setTemplates( updated );
+			setSaving( true );
+			setNotice( null );
+
+			const enabled = {};
+			updated.forEach( ( template ) => {
+				enabled[ template.slug ] = template.enabled;
+			} );
+
+			apiFetch( {
+				path: '/traktivity/v1/templates',
+				method: 'POST',
+				data: { enabled },
+			} )
+				.then( ( body ) => {
+					const stored = body?.templates || updated;
+					setTemplates( stored );
+					setSaved( stored );
+				} )
+				.catch( ( error ) => {
+					// Put the switch back where it was, so the screen matches the site.
+					setTemplates( templates );
+					setNotice(
+						error?.message ||
+							__(
+								'That change could not be saved.',
+								'traktivity'
+							)
+					);
+				} )
+				.finally( () => setSaving( false ) );
+		},
+		[ templates ]
+	);
+
+	const isSaved = useCallback(
+		( slug ) =>
+			saved.some(
+				( template ) => template.slug === slug && template.enabled
+			),
+		[ saved ]
+	);
+
+	if ( ! templates.length ) {
+		return null;
+	}
+
+	return (
+		<Card className="traktivity-templates">
+			<CardHeader>
+				<h2>{ __( 'Show your watch history', 'traktivity' ) }</h2>
+			</CardHeader>
+			<CardBody>
+				<p>
+					{ __(
+						'Traktivity can lay out your entries for you. Nothing here is on until you switch it on, and your theme always wins if it has its own version.',
+						'traktivity'
+					) }
+				</p>
+
+				{ ! settings.isBlockTheme && (
+					<Notice status="warning" isDismissible={ false }>
+						{ __(
+							'Your theme is a classic theme, so WordPress will not use any of these. They will start working if you switch to a block theme.',
+							'traktivity'
+						) }
+					</Notice>
+				) }
+
+				{ settings.isBlockTheme && ! settings.hasEvents && (
+					<Notice status="info" isDismissible={ false }>
+						{ __(
+							'Nothing has synced yet, so there is nothing to preview. Switch these on now if you like; they will fill in as entries arrive.',
+							'traktivity'
+						) }
+					</Notice>
+				) }
+
+				{ notice && (
+					<Notice status="error" onRemove={ () => setNotice( null ) }>
+						{ notice }
+					</Notice>
+				) }
+
+				<div className="traktivity-templates__grid">
+					{ templates.map( ( template ) => (
+						<TemplateCard
+							key={ template.slug }
+							template={ template }
+							disabled={ saving || ! settings.isBlockTheme }
+							editUrl={
+								isSaved( template.slug )
+									? editUrlFor( template )
+									: ''
+							}
+							onChange={ toggle }
+						/>
+					) ) }
+				</div>
+
+				{ settings.isBlockTheme && (
+					<p>
+						<Button
+							variant="link"
+							href={ settings.siteEditorUrl }
+							target="_blank"
+						>
+							{ __( 'Open the Site Editor', 'traktivity' ) }
+						</Button>
+					</p>
+				) }
+			</CardBody>
+		</Card>
+	);
+}

--- a/src/components/templates/illustrations.js
+++ b/src/components/templates/illustrations.js
@@ -1,0 +1,164 @@
+/**
+ * Wireframes for each template and part.
+ *
+ * Deliberately crude: enough to tell a grid from a hero from a band at a
+ * glance, and nothing that has to be redrawn when a block's styling changes.
+ * They use currentColor throughout so they follow the admin colour scheme
+ * rather than fighting it.
+ */
+
+/**
+ * Frame every wireframe shares.
+ *
+ * @param {Object}  props          Component props.
+ * @param {Element} props.children Shapes to draw inside the frame.
+ * @return {Element} The wireframe.
+ */
+function Frame( { children } ) {
+	return (
+		<svg
+			viewBox="0 0 120 80"
+			role="presentation"
+			focusable="false"
+			style={ { width: '100%', height: 'auto', display: 'block' } }
+		>
+			<rect
+				x="0.5"
+				y="0.5"
+				width="119"
+				height="79"
+				rx="3"
+				fill="none"
+				stroke="currentColor"
+				strokeOpacity="0.25"
+			/>
+			<g fill="currentColor" fillOpacity="0.25">
+				{ children }
+			</g>
+		</svg>
+	);
+}
+
+/** @return {Element} A single entry: image, title, meta rows. */
+export function SingleEntry() {
+	return (
+		<Frame>
+			<rect x="10" y="10" width="100" height="26" rx="2" />
+			<rect x="10" y="42" width="64" height="5" rx="2" />
+			<rect x="10" y="52" width="40" height="4" rx="2" />
+			<rect x="10" y="62" width="100" height="3" rx="1" />
+			<rect x="10" y="69" width="80" height="3" rx="1" />
+		</Frame>
+	);
+}
+
+/** @return {Element} An archive: a band above a grid of cards. */
+export function ArchiveGrid() {
+	return (
+		<Frame>
+			<rect x="10" y="8" width="100" height="8" rx="2" />
+			<rect x="10" y="24" width="46" height="24" rx="2" />
+			<rect x="64" y="24" width="46" height="24" rx="2" />
+			<rect x="10" y="54" width="46" height="18" rx="2" />
+			<rect x="64" y="54" width="46" height="18" rx="2" />
+		</Frame>
+	);
+}
+
+/** @return {Element} A series archive: header beside artwork, then episodes. */
+export function SeriesArchive() {
+	return (
+		<Frame>
+			<rect x="10" y="10" width="42" height="26" rx="2" />
+			<rect x="58" y="12" width="40" height="5" rx="2" />
+			<rect x="58" y="22" width="52" height="3" rx="1" />
+			<rect x="58" y="29" width="46" height="3" rx="1" />
+			<rect x="10" y="46" width="30" height="24" rx="2" />
+			<rect x="45" y="46" width="30" height="24" rx="2" />
+			<rect x="80" y="46" width="30" height="24" rx="2" />
+		</Frame>
+	);
+}
+
+/** @return {Element} A hero: one large image beside a title. */
+export function Hero() {
+	return (
+		<Frame>
+			<rect x="10" y="14" width="62" height="52" rx="2" />
+			<rect x="80" y="22" width="30" height="5" rx="2" />
+			<rect x="80" y="33" width="24" height="4" rx="2" />
+			<rect x="80" y="43" width="28" height="3" rx="1" />
+		</Frame>
+	);
+}
+
+/** @return {Element} A band of figures. */
+export function StatsBand() {
+	return (
+		<Frame>
+			<rect x="10" y="30" width="18" height="10" rx="2" />
+			<rect x="10" y="44" width="14" height="3" rx="1" />
+			<rect x="36" y="30" width="18" height="10" rx="2" />
+			<rect x="36" y="44" width="14" height="3" rx="1" />
+			<rect x="62" y="30" width="18" height="10" rx="2" />
+			<rect x="62" y="44" width="14" height="3" rx="1" />
+			<rect x="88" y="30" width="18" height="10" rx="2" />
+			<rect x="88" y="44" width="14" height="3" rx="1" />
+		</Frame>
+	);
+}
+
+/** @return {Element} An index: many small tiles. */
+export function SeriesIndex() {
+	return (
+		<Frame>
+			<rect x="10" y="10" width="30" height="18" rx="2" />
+			<rect x="45" y="10" width="30" height="18" rx="2" />
+			<rect x="80" y="10" width="30" height="18" rx="2" />
+			<rect x="10" y="33" width="30" height="18" rx="2" />
+			<rect x="45" y="33" width="30" height="18" rx="2" />
+			<rect x="80" y="33" width="30" height="18" rx="2" />
+			<rect x="10" y="56" width="30" height="14" rx="2" />
+			<rect x="45" y="56" width="30" height="14" rx="2" />
+		</Frame>
+	);
+}
+
+/** @return {Element} A narrow list, as in a sidebar. */
+export function CompactList() {
+	return (
+		<Frame>
+			<rect x="34" y="12" width="52" height="5" rx="2" />
+			<rect x="34" y="24" width="52" height="4" rx="2" />
+			<rect x="34" y="34" width="52" height="4" rx="2" />
+			<rect x="34" y="44" width="52" height="4" rx="2" />
+			<rect x="34" y="54" width="52" height="4" rx="2" />
+			<rect x="34" y="64" width="36" height="4" rx="2" />
+		</Frame>
+	);
+}
+
+/**
+ * Pick the wireframe for a slug.
+ *
+ * @param {string} slug Template or part slug.
+ * @return {Element} The wireframe to draw.
+ */
+export default function illustrationFor( slug ) {
+	switch ( slug ) {
+		case 'single-traktivity_event':
+			return <SingleEntry />;
+		case 'taxonomy-trakt_show':
+			return <SeriesArchive />;
+		case 'traktivity-latest-watch':
+			return <Hero />;
+		case 'traktivity-watch-stats':
+			return <StatsBand />;
+		case 'traktivity-series-index':
+			return <SeriesIndex />;
+		case 'traktivity-recent-compact':
+			return <CompactList />;
+		default:
+			return <ArchiveGrid />;
+	}
+}

--- a/src/settings.js
+++ b/src/settings.js
@@ -13,6 +13,18 @@
  *   syncPages: string,
  *   syncRuntime: string,
  *   totalTimeWatched: string,
+ *   templates: Array<{
+ *     slug: string,
+ *     type: string,
+ *     title: string,
+ *     description: string,
+ *     enabled: boolean,
+ *     themeProvides: boolean,
+ *   }>,
+ *   isBlockTheme: boolean,
+ *   themeStylesheet: string,
+ *   siteEditorUrl: string,
+ *   hasEvents: boolean,
  * }}
  */
 export default window.traktivityDashboard || {};

--- a/src/style.css
+++ b/src/style.css
@@ -90,3 +90,59 @@
 .traktivity-form .components-button {
 	width: auto;
 }
+
+/**
+ * Display settings.
+ *
+ * A grid of cards, one per template or part Traktivity can provide. The
+ * wireframes carry the selected state, since the checkbox alone is easy to
+ * miss at a glance.
+ */
+
+.traktivity-templates__grid {
+	display: grid;
+	gap: 24px;
+	grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+	margin-top: 16px;
+}
+
+.traktivity-template-card__surface {
+	background: #fff;
+	border: 2px solid #dcdcde;
+	border-radius: 4px;
+	color: #1e1e1e;
+	cursor: pointer;
+	display: block;
+	padding: 12px;
+}
+
+.traktivity-template-card__surface[data-checked="true"] {
+	border-color: #3858e9;
+}
+
+.traktivity-template-card__surface:hover {
+	border-color: #949494;
+}
+
+.traktivity-template-card__body {
+	align-items: flex-start;
+	display: flex;
+	gap: 4px;
+	margin-top: 8px;
+}
+
+.traktivity-template-card__title {
+	font-weight: 600;
+	margin: 0;
+}
+
+.traktivity-template-card__description,
+.traktivity-template-card__note {
+	color: #50575e;
+	font-size: 12px;
+	margin: 4px 0 0;
+}
+
+.traktivity-template-card__note {
+	font-style: italic;
+}

--- a/templates.traktivity.php
+++ b/templates.traktivity.php
@@ -275,6 +275,101 @@ class Traktivity_Templates {
 	}
 
 	/**
+	 * Which of our template slugs the active theme already covers.
+	 *
+	 * A theme's own template wins over ours, so offering to switch one on when
+	 * the theme already answers for it would be offering nothing. Asked once
+	 * for every slug rather than once per template.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @return string[] Slugs the theme provides.
+	 */
+	public static function theme_provided_slugs(): array {
+		if ( ! wp_is_block_theme() || ! function_exists( 'get_block_templates' ) ) {
+			return array();
+		}
+
+		$slugs = array_keys( self::available() );
+		$found = get_block_templates( array( 'slug__in' => $slugs ), 'wp_template' );
+		$ours  = array();
+
+		foreach ( $found as $template ) {
+			if ( 'theme' === $template->source ) {
+				$ours[] = $template->slug;
+			}
+		}
+
+		return array_values( array_unique( $ours ) );
+	}
+
+	/**
+	 * Everything the settings screen needs to describe what we can provide.
+	 *
+	 * Templates and parts in one list, each carrying the type the Site Editor
+	 * wants in a URL, so the dashboard does not have to know which is which.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public static function for_settings(): array {
+		$theme_provides = self::theme_provided_slugs();
+		$entries        = array();
+
+		foreach ( self::available() as $slug => $template ) {
+			$entries[] = array(
+				'slug'          => $slug,
+				'type'          => 'wp_template',
+				'title'         => $template['title'],
+				'description'   => $template['description'],
+				'enabled'       => self::is_enabled( $slug ),
+				'themeProvides' => in_array( $slug, $theme_provides, true ),
+			);
+		}
+
+		foreach ( self::available_parts() as $slug => $part ) {
+			$entries[] = array(
+				'slug'          => $slug,
+				'type'          => 'wp_template_part',
+				'title'         => $part['title'],
+				'description'   => $part['description'],
+				'enabled'       => self::is_enabled( $slug ),
+				'themeProvides' => false,
+			);
+		}
+
+		return $entries;
+	}
+
+	/**
+	 * Save which templates and parts are switched on.
+	 *
+	 * Only slugs this plugin knows about are stored, so a stale or invented
+	 * key cannot accumulate in the option.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param array $enabled Slug => boolean.
+	 *
+	 * @return array The stored value.
+	 */
+	public static function save_enabled( array $enabled ): array {
+		$known = array_merge( array_keys( self::available() ), array_keys( self::available_parts() ) );
+		$clean = array();
+
+		foreach ( $known as $slug ) {
+			if ( ! empty( $enabled[ $slug ] ) ) {
+				$clean[ $slug ] = true;
+			}
+		}
+
+		update_option( self::OPTION, $clean );
+
+		return $clean;
+	}
+
+	/**
 	 * The ID a template part is known by.
 	 *
 	 * Namespaced to the active theme on purpose. The moment someone edits one

--- a/tests/js/settings-mock.js
+++ b/tests/js/settings-mock.js
@@ -14,6 +14,11 @@ const settings = {
 	syncPages: '0',
 	syncRuntime: '',
 	totalTimeWatched: '',
+	templates: [],
+	isBlockTheme: false,
+	themeStylesheet: '',
+	siteEditorUrl: '',
+	hasEvents: false,
 };
 
 export function resetSettings( overrides = {} ) {
@@ -22,6 +27,9 @@ export function resetSettings( overrides = {} ) {
 	} );
 	settings.step = '1';
 	settings.syncPages = '0';
+	settings.templates = [];
+	settings.isBlockTheme = false;
+	settings.hasEvents = false;
 	Object.assign( settings, overrides );
 }
 

--- a/tests/js/template-settings.test.js
+++ b/tests/js/template-settings.test.js
@@ -1,0 +1,210 @@
+/**
+ * External dependencies
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import TemplateSettings from '../../src/components/templates/TemplateSettings';
+import { resetSettings } from './settings-mock';
+
+jest.mock( '../../src/settings', () => require( './settings-mock' ) );
+jest.mock( '@wordpress/api-fetch' );
+
+const TEMPLATE = {
+	slug: 'archive-traktivity_event',
+	type: 'wp_template',
+	title: 'Everything watched',
+	description: 'The full archive of what you have watched.',
+	enabled: false,
+	themeProvides: false,
+};
+
+const PART = {
+	slug: 'traktivity-watch-stats',
+	type: 'wp_template_part',
+	title: 'Watch totals',
+	description: 'Hours, entries, episodes, films and series, as a band.',
+	enabled: false,
+	themeProvides: false,
+};
+
+/**
+ * Set up the settings a test needs.
+ *
+ * @param {Object} overrides Values to apply on top of the block-theme default.
+ */
+function withSettings( overrides = {} ) {
+	resetSettings( {
+		isBlockTheme: true,
+		hasEvents: true,
+		themeStylesheet: 'twentytwentyfour',
+		siteEditorUrl: 'http://example.org/wp-admin/site-editor.php',
+		templates: [ TEMPLATE, PART ],
+		...overrides,
+	} );
+}
+
+describe( 'TemplateSettings', () => {
+	beforeEach( () => {
+		apiFetch.mockReset();
+		apiFetch.mockResolvedValue( { templates: [] } );
+	} );
+
+	it( 'renders nothing when the plugin offers no templates', () => {
+		withSettings( { templates: [] } );
+
+		const { container } = render( <TemplateSettings /> );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'lists what the plugin can provide', () => {
+		withSettings();
+
+		render( <TemplateSettings /> );
+
+		expect( screen.getByText( 'Everything watched' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Watch totals' ) ).toBeInTheDocument();
+	} );
+
+	it( 'says a template part has to be placed by hand', () => {
+		withSettings();
+
+		render( <TemplateSettings /> );
+
+		expect(
+			screen.getByText( /add a Template Part block wherever you want it/ )
+		).toBeInTheDocument();
+	} );
+
+	/*
+	 * getAllByText throughout for notice copy: @wordpress/components mirrors a
+	 * Notice into an aria-live region, so the text is genuinely in the
+	 * document twice and getByText would fail on the duplicate.
+	 */
+	it( 'warns that a classic theme will not use any of this', () => {
+		withSettings( { isBlockTheme: false } );
+
+		render( <TemplateSettings /> );
+
+		expect(
+			screen.getAllByText( /Your theme is a classic theme/ ).length
+		).toBeGreaterThan( 0 );
+	} );
+
+	it( 'says there is nothing to preview before the first sync', () => {
+		withSettings( { hasEvents: false } );
+
+		render( <TemplateSettings /> );
+
+		expect(
+			screen.getAllByText( /Nothing has synced yet/ ).length
+		).toBeGreaterThan( 0 );
+	} );
+
+	it( 'flags a template the theme already covers', () => {
+		withSettings( {
+			templates: [ { ...TEMPLATE, themeProvides: true } ],
+		} );
+
+		render( <TemplateSettings /> );
+
+		expect(
+			screen.getByText( /Your theme already has a template for this/ )
+		).toBeInTheDocument();
+	} );
+
+	it( 'saves a change', async () => {
+		withSettings();
+		apiFetch.mockResolvedValue( {
+			templates: [ { ...TEMPLATE, enabled: true }, PART ],
+		} );
+
+		render( <TemplateSettings /> );
+		await userEvent.click( screen.getAllByRole( 'checkbox' )[ 0 ] );
+
+		await waitFor( () =>
+			expect( apiFetch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					path: '/traktivity/v1/templates',
+					method: 'POST',
+					data: {
+						enabled: {
+							'archive-traktivity_event': true,
+							'traktivity-watch-stats': false,
+						},
+					},
+				} )
+			)
+		);
+	} );
+
+	it( 'puts the switch back when saving fails', async () => {
+		withSettings();
+		apiFetch.mockRejectedValue( { message: 'Nope.' } );
+
+		render( <TemplateSettings /> );
+		const checkbox = screen.getAllByRole( 'checkbox' )[ 0 ];
+		await userEvent.click( checkbox );
+
+		await waitFor( () =>
+			expect( screen.getAllByText( 'Nope.' ).length ).toBeGreaterThan( 0 )
+		);
+		expect( checkbox ).not.toBeChecked();
+	} );
+
+	it( 'only offers an edit link once the change is saved', async () => {
+		withSettings();
+		apiFetch.mockResolvedValue( {
+			templates: [ { ...TEMPLATE, enabled: true }, PART ],
+		} );
+
+		render( <TemplateSettings /> );
+
+		// Nothing is enabled yet, so there is nothing worth linking to.
+		expect(
+			screen.queryByText( 'Preview and edit' )
+		).not.toBeInTheDocument();
+
+		await userEvent.click( screen.getAllByRole( 'checkbox' )[ 0 ] );
+
+		await waitFor( () =>
+			expect( screen.getByText( 'Preview and edit' ) ).toBeInTheDocument()
+		);
+	} );
+
+	it( 'hides edit links on a classic theme rather than linking nowhere', async () => {
+		withSettings( {
+			isBlockTheme: false,
+			templates: [ { ...TEMPLATE, enabled: true } ],
+		} );
+
+		render( <TemplateSettings /> );
+
+		expect(
+			screen.queryByText( 'Preview and edit' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'points the edit link at the right template in the Site Editor', async () => {
+		withSettings( {
+			templates: [ { ...TEMPLATE, enabled: true } ],
+		} );
+
+		render( <TemplateSettings /> );
+
+		const link = screen.getByText( 'Preview and edit' ).closest( 'a' );
+
+		expect( link ).toHaveAttribute(
+			'href',
+			expect.stringContaining( 'postType=wp_template' )
+		);
+		expect( link.getAttribute( 'href' ) ).toContain(
+			encodeURIComponent( 'twentytwentyfour//archive-traktivity_event' )
+		);
+	} );
+} );

--- a/tests/php/TemplateSettingsRestTest.php
+++ b/tests/php/TemplateSettingsRestTest.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * Tests for the template settings endpoints.
+ *
+ * @package Traktivity
+ */
+
+/**
+ * Reading and writing which templates are switched on.
+ */
+class TemplateSettingsRestTest extends WP_UnitTestCase {
+
+	/**
+	 * Stand up the REST server and start from a clean option.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		delete_option( Traktivity_Templates::OPTION );
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Make a request.
+	 *
+	 * @param string $method HTTP method.
+	 * @param array  $body   Request body.
+	 *
+	 * @return WP_REST_Response
+	 */
+	private function request( $method, array $body = array() ) {
+		$request = new WP_REST_Request( $method, '/traktivity/v1/templates' );
+
+		if ( ! empty( $body ) ) {
+			$request->set_header( 'content-type', 'application/json' );
+			$request->set_body( wp_json_encode( $body ) );
+		}
+
+		return rest_get_server()->dispatch( $request );
+	}
+
+	/**
+	 * Become an administrator.
+	 */
+	private function log_in_as_admin() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+	}
+
+	/**
+	 * A visitor cannot read the settings.
+	 *
+	 * These say what a site's admin screens look like, which is nobody else's
+	 * business.
+	 */
+	public function test_reading_requires_a_capability() {
+		wp_set_current_user( 0 );
+
+		$this->assertSame( 401, $this->request( 'GET' )->get_status() );
+	}
+
+	/**
+	 * A subscriber cannot write them either.
+	 */
+	public function test_writing_requires_a_capability() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$response = $this->request( 'POST', array( 'enabled' => array( 'single-traktivity_event' => true ) ) );
+
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertFalse( Traktivity_Templates::is_enabled( 'single-traktivity_event' ) );
+	}
+
+	/**
+	 * An administrator gets the full list, with everything off.
+	 */
+	public function test_reading_returns_everything_available() {
+		$this->log_in_as_admin();
+
+		$response = $this->request( 'GET' );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertArrayHasKey( 'templates', $data );
+		$this->assertArrayHasKey( 'isBlockTheme', $data );
+		$this->assertArrayHasKey( 'themeStylesheet', $data );
+
+		$slugs = wp_list_pluck( $data['templates'], 'slug' );
+
+		$this->assertContains( 'single-traktivity_event', $slugs );
+		$this->assertContains( 'traktivity-watch-stats', $slugs );
+
+		foreach ( $data['templates'] as $template ) {
+			$this->assertFalse( $template['enabled'], "{$template['slug']} is on by default." );
+		}
+	}
+
+	/**
+	 * Every entry says which kind it is, so the dashboard can link to it.
+	 */
+	public function test_entries_carry_their_type() {
+		$this->log_in_as_admin();
+
+		$types = wp_list_pluck( $this->request( 'GET' )->get_data()['templates'], 'type', 'slug' );
+
+		$this->assertSame( 'wp_template', $types['single-traktivity_event'] );
+		$this->assertSame( 'wp_template_part', $types['traktivity-watch-stats'] );
+	}
+
+	/**
+	 * Switching one on persists it.
+	 */
+	public function test_writing_persists() {
+		$this->log_in_as_admin();
+
+		$response = $this->request(
+			'POST',
+			array( 'enabled' => array( 'archive-traktivity_event' => true ) )
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertTrue( Traktivity_Templates::is_enabled( 'archive-traktivity_event' ) );
+		$this->assertFalse( Traktivity_Templates::is_enabled( 'single-traktivity_event' ) );
+	}
+
+	/**
+	 * The response reports the stored state, not what was sent.
+	 */
+	public function test_response_reports_stored_state() {
+		$this->log_in_as_admin();
+
+		$data  = $this->request( 'POST', array( 'enabled' => array( 'taxonomy-trakt_show' => true ) ) )->get_data();
+		$state = wp_list_pluck( $data['templates'], 'enabled', 'slug' );
+
+		$this->assertTrue( $state['taxonomy-trakt_show'] );
+		$this->assertFalse( $state['single-traktivity_event'] );
+	}
+
+	/**
+	 * Switching everything off stores nothing rather than a list of falses.
+	 */
+	public function test_turning_everything_off() {
+		$this->log_in_as_admin();
+
+		$this->request( 'POST', array( 'enabled' => array( 'single-traktivity_event' => true ) ) );
+		$this->request( 'POST', array( 'enabled' => array( 'single-traktivity_event' => false ) ) );
+
+		$this->assertSame( array(), get_option( Traktivity_Templates::OPTION ) );
+	}
+
+	/**
+	 * An unknown slug is dropped rather than stored.
+	 *
+	 * A key from an older version, or an invented one, would otherwise sit in
+	 * the option forever.
+	 */
+	public function test_unknown_slugs_are_dropped() {
+		$this->log_in_as_admin();
+
+		$this->request(
+			'POST',
+			array(
+				'enabled' => array(
+					'single-traktivity_event' => true,
+					'made-up-slug'            => true,
+				),
+			)
+		);
+
+		$this->assertSame( array( 'single-traktivity_event' => true ), get_option( Traktivity_Templates::OPTION ) );
+	}
+
+	/**
+	 * A request with no list is rejected.
+	 */
+	public function test_missing_list_is_rejected() {
+		$this->log_in_as_admin();
+
+		$this->assertSame( 400, $this->request( 'POST' )->get_status() );
+	}
+
+	/**
+	 * A template the theme already covers is flagged.
+	 *
+	 * A theme's own template wins, so offering to switch ours on without
+	 * saying so would be offering nothing.
+	 */
+	public function test_theme_provided_templates_are_flagged() {
+		$this->log_in_as_admin();
+
+		$flags = wp_list_pluck( $this->request( 'GET' )->get_data()['templates'], 'themeProvides', 'slug' );
+
+		$this->assertArrayHasKey( 'single-traktivity_event', $flags );
+		$this->assertIsBool( $flags['single-traktivity_event'] );
+		$this->assertFalse( $flags['traktivity-watch-stats'], 'A part is never theme-provided.' );
+	}
+}


### PR DESCRIPTION
Fixes #698

## What it does

A "Show your watch history" section on the dashboard, listing every template and
part Traktivity can provide as a grid of cards: a wireframe, a checkbox, and a
link straight into the Site Editor.

Two new REST routes on `traktivity/v1/templates` read and write the option, both
behind the existing capability check.

## Rationale

Everything #697 and #699 added is off by default, so this section is the only way
anyone learns it exists. A fresh install shows bare episode names until someone
comes here, which means the cards have to do the explaining the default would
otherwise have done.

Details worth flagging:

- **The edit link follows what's been saved, not what's on screen.** The
  component keeps both. Link off the optimistic value and someone ticks a box,
  clicks straight through, and lands on a template that was never registered.
  There's a test for it.
- **On a classic theme the links aren't rendered at all**, rather than rendered
  and disabled. A link that goes somewhere useless is worse than no link.
- **Three honest states**, each with its own message: a classic theme won't use
  any of this, nothing has synced so there's nothing to preview, and this
  template is one the active theme already covers — a theme's own wins, so
  switching ours on would change nothing.
- **Template parts say they aren't placed for you.** Their switch governs whether
  the part is *offered*, not whether it appears anywhere, so the card says to add
  a Template Part block. Without that, people tick a box, see no change, and file
  a bug.
- **Unknown slugs are dropped**, not stored, so a key from an older version can't
  accumulate in the option.
- **The card's label wraps only the wireframe**, so clicking the picture toggles
  the checkbox while the title and the edit link don't, and the visible title is
  borrowed as the checkbox's accessible name via `aria-labelledby` rather than
  repeated in a hidden one.

The wireframes are deliberately crude and drawn in `currentColor`, so they follow
the admin colour scheme and don't need redrawing every time a block's styling
changes.

## One test note

Notice copy is asserted with `getAllByText`. `@wordpress/components` mirrors a
`Notice` into an `aria-live` region, so the text really is in the document twice
and `getByText` fails on the duplicate. Worth knowing before someone "fixes" it.

## Testing

`composer run lint && composer run analyse` clean. PHPUnit 269 passing, 600
assertions. Jest 55 passing. Build, package check and both linters pass.

PHP coverage: reading and writing both requiring a capability, the full list
coming back with everything off, entries carrying their type, writing persisting,
the response reporting stored state rather than what was sent, turning everything
off storing nothing, unknown slugs dropped, a missing list rejected, and
theme-provided templates flagged.

JS coverage: rendering nothing with no templates, listing what's available, the
template-part note, the classic-theme warning, the empty-site message, the
theme-provides flag, saving a change, the switch going back when a save fails,
the edit link only appearing once saved, links hidden on a classic theme, and the
link pointing at the right template.

## Where this leaves 3.1.0

This was the last sub-issue. The feature branch now carries the full milestone;
what's left is a version bump, a changelog, and someone actually looking at it.
