### PR TITLE
Prepare 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Log your activity on Trakt.tv. The released plugin lives on
 [wordpress.org](https://wordpress.org/plugins/traktivity/); `readme.txt` is the
 copy that ships there.
 
-This file covers working on the plugin.
+This file covers working on the plugin. `AGENTS.md` covers the conventions a
+change has to follow, and `src/blocks/README.md` covers adding a block.
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "traktivity",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Log your activity on Trakt.tv",
   "main": "traktivity.php",
   "files": [

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Traktivity ===
 Contributors: jeherve
 Tags: Trakt.tv, TV, Activity, Movies, Log
-Stable tag: 3.0.1
+Stable tag: 3.1.0
 Requires at least: 7.0
 Tested up to: 7.1
 Requires PHP: 7.4
@@ -15,7 +15,7 @@ This plugin allows you to log your watched TV series on Trakt.tv.
 
 **You need a Trakt.tv VIP account to set this up.** The plugin reads your watch history through the Trakt.tv API, and since the middle of 2026 only VIP accounts can create the API application that key comes from. If you already had a key before that change, it should keep working. See the FAQ below for the details. :(
 
-Right now it only logs data. In the next version you will get ways to display that data on your site.
+Since 3.1.0 it also gives you ways to show that data. Seven blocks, default templates for your entries and archives, and a handful of editable parts you can drop wherever you like. All of it is off until you switch it on, from Traktivity > Dashboard.
 
 **Questions, problems?**
 
@@ -66,10 +66,44 @@ There is more discussion in [issue #678](https://github.com/jeherve/traktivity/i
 
 == Upgrade Notice ==
 
+= 3.1.0 =
+Adds blocks and templates for showing your watch history. Nothing changes on your site until you switch them on.
+
 = 3.0.0 =
 Needs WordPress 7.0 and PHP 7.4.
 
 == Changelog ==
+
+= 3.1.0 =
+Release date: September 4, 2026
+
+Traktivity has always logged your watch history and done almost nothing with it. This release is about showing it.
+
+**Blocks**
+
+* Add seven blocks, grouped under Traktivity in the inserter: Event Card, Event Title, Event Details, Watch Stats, Top Series, Latest Watch and Series Header.
+* Event Card and Event Title put an episode's series name and season and episode numbers back into its title, so a listing reads as something other than a column of episode names.
+* Top Series orders your series by how many episodes you have logged, which a Query Loop cannot do. Set it to zero to get a full A to Z index instead.
+* Latest Watch prefers the most recent entry that actually has artwork, since TMDb does not have an image for everything.
+
+**Templates**
+
+* Add default block templates for a single entry, the full archive, a series, and the genre, year and type archives.
+* Add five editable template parts: recently watched, last watched, watch totals, a series index, and a compact list for a sidebar.
+* Everything is off until you switch it on, from Traktivity > Dashboard. Your own theme's templates always win.
+* Read a single series' archive oldest first, since a series is a run watched in order.
+
+**For developers**
+
+* Add accessors for reading a watch event, its title and its external links, and for reading what is stored against a series. See `helpers.traktivity.php`.
+* Add `Traktivity_Stats::get_summary()` for the headline totals.
+* Register the term meta stored against each series, so it appears in the REST API.
+
+**Fixes**
+
+* Recount the total time watched when an entry is deleted. It used to only ever be added to, so deleting an entry left the total too high with no way to correct it.
+* Attach a season term to specials, which land in season 0. Nothing has ever recorded a season for them. Entries synced before this update keep their missing season; re-syncing does not revisit them.
+* Show the episode details in the Recently Watched widget on sites not running in English, where they were silently dropped.
 
 = 3.0.1 =
 Release date: September 3, 2026

--- a/traktivity.php
+++ b/traktivity.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://wordpress.org/plugins/traktivity
  * Description: Log your activity on Trakt.tv
  * Author: Jeremy Herve
- * Version: 3.0.1
+ * Version: 3.1.0
  * Author URI: https://jeremy.hu
  * Requires at least: 7.0
  * Requires PHP: 7.4
@@ -17,7 +17,7 @@
 
 defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
 
-define( 'TRAKTIVITY__VERSION', '3.0.1' );
+define( 'TRAKTIVITY__VERSION', '3.1.0' );
 define( 'TRAKTIVITY__API_URL', 'https://api.trakt.tv' );
 define( 'TRAKTIVITY__API_VERSION', '2' );
 define( 'TRAKTIVITY__TMDB_API_URL', 'https://api.themoviedb.org' );


### PR DESCRIPTION
Part of #683. The last change on the feature branch before it goes to `master`.

## What it does

Bumps the version to 3.1.0 across `traktivity.php`, `readme.txt` and
`package.json`, and writes the changelog.

Also rewrites the sentence in `readme.txt` that has been promising this release
for a while:

> Right now it only logs data. In the next version you will get ways to display
> that data on your site.

## Rationale

The changelog leads with what a site owner gets rather than with the accessors,
and says plainly that nothing changes until they switch it on — that's the first
question an update like this raises.

Two entries under Fixes are worth reading rather than skimming:

- **Specials have never had a season recorded**, and entries synced before this
  update keep that gap, because re-syncing skips events that already exist. The
  changelog says so rather than leaving people to notice.
- **The Recently Watched widget's episode details have never appeared on a site
  running in anything but English.** Nobody reported it because nobody running in
  English could see it.

`README.md` now points at `AGENTS.md` and `src/blocks/README.md`, which is where
the conventions moved.

## Testing

Package check confirms the version bump is consistent:

```
ok    plugin header version matches readme stable tag (3.1.0 / 3.1.0)
```

PHPUnit 269 passing, phpcs clean.
