### PR TITLE
Fix two layout problems only visible in a browser

### DIFF
--- a/src/blocks/latest-watch/render.php
+++ b/src/blocks/latest-watch/render.php
@@ -86,15 +86,23 @@ $traktivity_kicker = isset( $attributes['kicker'] ) ? (string) $attributes['kick
 $traktivity_wrapper = get_block_wrapper_attributes( array( 'class' => 'traktivity-hero' ) );
 ?>
 <section <?php echo $traktivity_wrapper; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Prepared by get_block_wrapper_attributes(). ?>>
-	<?php if ( '' !== $traktivity_kicker ) : ?>
-		<p class="traktivity-hero__kicker"><?php echo esc_html( $traktivity_kicker ); ?></p>
-	<?php endif; ?>
-
 	<a class="traktivity-hero__link" href="<?php echo esc_url( $traktivity_event['permalink'] ); ?>" tabindex="-1" aria-hidden="true">
 		<?php echo Traktivity_Blocks::frame( $traktivity_event['image_id'], $traktivity_event['title'], 'landscape' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped in Traktivity_Blocks::frame(). ?>
 	</a>
 
+	<?php
+	/*
+	 * The kicker belongs inside the body rather than beside it. The wrapper is
+	 * a two-column grid, so a third child at this level takes a cell of its
+	 * own: the kicker sat next to the image and pushed everything else onto a
+	 * second row, leaving a hole where the text should have been.
+	 */
+	?>
 	<div class="traktivity-hero__body">
+		<?php if ( '' !== $traktivity_kicker ) : ?>
+			<p class="traktivity-hero__kicker"><?php echo esc_html( $traktivity_kicker ); ?></p>
+		<?php endif; ?>
+
 		<?php if ( '' !== $traktivity_event['show_name'] && '' !== $traktivity_event['show_link'] ) : ?>
 			<p class="traktivity-hero__show">
 				<a href="<?php echo esc_url( $traktivity_event['show_link'] ); ?>"><?php echo esc_html( $traktivity_event['show_name'] ); ?></a>

--- a/templates.traktivity.php
+++ b/templates.traktivity.php
@@ -42,7 +42,7 @@ class Traktivity_Templates {
 	public static function init(): void {
 		add_action( 'init', array( __CLASS__, 'register_templates' ), 20 );
 		add_filter( 'get_block_template', array( __CLASS__, 'provide_template_part' ), 10, 3 );
-		add_action( 'pre_get_posts', array( __CLASS__, 'order_show_archive' ) );
+		add_action( 'pre_get_posts', array( __CLASS__, 'shape_archive_query' ) );
 	}
 
 	/**
@@ -200,37 +200,87 @@ class Traktivity_Templates {
 	}
 
 	/**
-	 * Read a single series' archive oldest first.
+	 * Shape the archive queries our templates inherit.
 	 *
-	 * A series is a run, watched in order, so newest-first is simply the wrong
-	 * way round for it. Only applied while our own series template is in use,
-	 * since a theme's template is entitled to its own ordering.
+	 * Two things the templates cannot do for themselves.
+	 *
+	 * A Query Loop with `inherit` set takes its page size from the main query,
+	 * which means from the site's "Blog pages show at most" setting rather than
+	 * from the `perPage` in the template. At the default of ten that leaves a
+	 * four-column grid two and a half rows tall, so the number the template
+	 * declares is set here instead of being quietly ignored.
+	 *
+	 * And a single series reads oldest first, because a series is a run watched
+	 * in order and newest-first is the wrong way round for it.
+	 *
+	 * Both apply only while our own template is in use. A theme's template is
+	 * entitled to its own ordering and its own page size.
 	 *
 	 * @since 3.1.0
 	 *
 	 * @param WP_Query $query The query about to run.
 	 */
-	public static function order_show_archive( $query ): void {
-		if (
-			! $query instanceof WP_Query
-			|| is_admin()
-			|| ! $query->is_main_query()
-			|| ! $query->is_tax( 'trakt_show' )
-			|| ! self::is_enabled( 'taxonomy-trakt_show' )
-		) {
+	public static function shape_archive_query( $query ): void {
+		if ( ! $query instanceof WP_Query || is_admin() || ! $query->is_main_query() ) {
 			return;
 		}
 
+		if ( $query->is_tax( 'trakt_show' ) && self::is_enabled( 'taxonomy-trakt_show' ) ) {
+			/**
+			 * Filter the order a single series' archive reads in.
+			 *
+			 * @since 3.1.0
+			 *
+			 * @param string $order Either ASC or DESC. Defaults to ASC.
+			 */
+			$order = (string) apply_filters( 'traktivity_show_archive_order', 'ASC' );
+
+			$query->set( 'order', 'DESC' === strtoupper( $order ) ? 'DESC' : 'ASC' );
+			$query->set( 'posts_per_page', self::posts_per_page( 'taxonomy-trakt_show', 48 ) );
+
+			return;
+		}
+
+		if ( $query->is_post_type_archive( 'traktivity_event' ) && self::is_enabled( 'archive-traktivity_event' ) ) {
+			$query->set( 'posts_per_page', self::posts_per_page( 'archive-traktivity_event', 24 ) );
+
+			return;
+		}
+
+		foreach ( array( 'trakt_genre', 'trakt_year', 'trakt_type' ) as $taxonomy ) {
+			if ( $query->is_tax( $taxonomy ) && self::is_enabled( 'taxonomy-' . $taxonomy ) ) {
+				$query->set( 'posts_per_page', self::posts_per_page( 'taxonomy-' . $taxonomy, 24 ) );
+
+				return;
+			}
+		}
+	}
+
+	/**
+	 * How many entries one of our archives shows per page.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param string $slug    Template slug the number belongs to.
+	 * @param int    $default_count What the template's own markup declares.
+	 *
+	 * @return int Entries per page.
+	 */
+	private static function posts_per_page( string $slug, int $default_count ): int {
 		/**
-		 * Filter the order a single series' archive reads in.
+		 * Filter how many entries one of Traktivity's archives shows per page.
+		 *
+		 * Return the site's own setting to hand control back to it:
+		 * `get_option( 'posts_per_page' )`.
 		 *
 		 * @since 3.1.0
 		 *
-		 * @param string $order Either ASC or DESC. Defaults to ASC.
+		 * @param int    $default_count Entries per page.
+		 * @param string $slug          Template slug.
 		 */
-		$order = (string) apply_filters( 'traktivity_show_archive_order', 'ASC' );
+		$number = (int) apply_filters( 'traktivity_archive_posts_per_page', $default_count, $slug );
 
-		$query->set( 'order', 'DESC' === strtoupper( $order ) ? 'DESC' : 'ASC' );
+		return $number > 0 ? $number : $default_count;
 	}
 
 	/**

--- a/tests/php/BlockTemplatesTest.php
+++ b/tests/php/BlockTemplatesTest.php
@@ -242,7 +242,7 @@ class BlockTemplatesTest extends WP_UnitTestCase {
 		$previous = $GLOBALS['wp_the_query'];
 
 		$GLOBALS['wp_the_query'] = $query;
-		Traktivity_Templates::order_show_archive( $query );
+		Traktivity_Templates::shape_archive_query( $query );
 		$GLOBALS['wp_the_query'] = $previous;
 
 		$this->assertSame( 'ASC', $query->get( 'order' ) );
@@ -256,10 +256,77 @@ class BlockTemplatesTest extends WP_UnitTestCase {
 		$previous = $GLOBALS['wp_the_query'];
 
 		$GLOBALS['wp_the_query'] = $query;
-		Traktivity_Templates::order_show_archive( $query );
+		Traktivity_Templates::shape_archive_query( $query );
 		$GLOBALS['wp_the_query'] = $previous;
 
 		$this->assertSame( '', $query->get( 'order' ) );
+	}
+
+	/**
+	 * Our archives show the number of entries their markup declares.
+	 *
+	 * A Query Loop with inherit set takes its page size from the main query,
+	 * so the perPage in the template is ignored and the site's "Blog pages
+	 * show at most" wins. At the default of ten that leaves a four-column grid
+	 * two and a half rows tall.
+	 */
+	public function test_archive_page_size_follows_the_template() {
+		$this->enable( array( 'archive-traktivity_event', 'taxonomy-trakt_show' ) );
+
+		$archive             = new WP_Query();
+		$archive->is_archive = true;
+		$archive->set( 'post_type', 'traktivity_event' );
+		$archive->is_post_type_archive = true;
+
+		$previous                = $GLOBALS['wp_the_query'];
+		$GLOBALS['wp_the_query'] = $archive;
+		Traktivity_Templates::shape_archive_query( $archive );
+
+		$series                  = $this->series_archive_query( 'paged-series' );
+		$GLOBALS['wp_the_query'] = $series;
+		Traktivity_Templates::shape_archive_query( $series );
+		$GLOBALS['wp_the_query'] = $previous;
+
+		$this->assertSame( 24, $archive->get( 'posts_per_page' ) );
+		$this->assertSame( 48, $series->get( 'posts_per_page' ) );
+	}
+
+	/**
+	 * The page size is filterable, so a site can hand control back to itself.
+	 */
+	public function test_archive_page_size_is_filterable() {
+		$this->enable( array( 'archive-traktivity_event' ) );
+
+		add_filter( 'traktivity_archive_posts_per_page', static fn() => 5 );
+
+		$archive                       = new WP_Query();
+		$archive->is_archive           = true;
+		$archive->is_post_type_archive = true;
+		$archive->set( 'post_type', 'traktivity_event' );
+
+		$previous                = $GLOBALS['wp_the_query'];
+		$GLOBALS['wp_the_query'] = $archive;
+		Traktivity_Templates::shape_archive_query( $archive );
+		$GLOBALS['wp_the_query'] = $previous;
+
+		$this->assertSame( 5, $archive->get( 'posts_per_page' ) );
+	}
+
+	/**
+	 * An archive whose template is off keeps the site's own page size.
+	 */
+	public function test_page_size_untouched_when_the_template_is_off() {
+		$archive                       = new WP_Query();
+		$archive->is_archive           = true;
+		$archive->is_post_type_archive = true;
+		$archive->set( 'post_type', 'traktivity_event' );
+
+		$previous                = $GLOBALS['wp_the_query'];
+		$GLOBALS['wp_the_query'] = $archive;
+		Traktivity_Templates::shape_archive_query( $archive );
+		$GLOBALS['wp_the_query'] = $previous;
+
+		$this->assertSame( '', $archive->get( 'posts_per_page' ) );
 	}
 
 	/**
@@ -279,6 +346,6 @@ class BlockTemplatesTest extends WP_UnitTestCase {
 	 */
 	public function test_registration_is_hooked() {
 		$this->assertNotFalse( has_action( 'init', array( 'Traktivity_Templates', 'register_templates' ) ) );
-		$this->assertNotFalse( has_action( 'pre_get_posts', array( 'Traktivity_Templates', 'order_show_archive' ) ) );
+		$this->assertNotFalse( has_action( 'pre_get_posts', array( 'Traktivity_Templates', 'shape_archive_query' ) ) );
 	}
 }


### PR DESCRIPTION
Part of #683. Two bugs found smoke testing the finished branch against a real
site with 920 synced entries.

The suite was green through both. That's the point: asserting markup contains a
string can't tell you the page looks wrong.

## The hero put its kicker beside the image

`.traktivity-hero` is a two-column grid, and the kicker was a third child at that
level. So it took a cell of its own, pushed the image into column two, and
dropped the body onto row two — leaving a hole where the text should have been.

```
before: [kicker    ] [image]     after: [image] [kicker    ]
        [body      ] [     ]            [     ] [show      ]
                                        [     ] [title     ]
```

Measured, before and after:

```
before  children: [kicker, link, body]  rows: 432, 371, 531  height: 251
after   children: [link, body]          rows: 371, 418       height: 211
```

The kicker belongs inside the body, which is where it reads.

## The archives showed 10 entries, not 24 and 48

A Query Loop with `inherit` set takes its page size from the main query, so the
`perPage` in the template is ignored and the site's "Blog pages show at most"
wins. At the default of ten that leaves a four-column grid two and a half rows
tall, and the number in the template markup was simply a lie.

`shape_archive_query()` now sets the number the template declares. Verified in
the browser: the event archive renders 24 across 4 columns over 39 pages, and The
Rookie's archive renders 48, still oldest-first, over 3 pages.

Both the ordering and the page size apply only while our own template is in use —
a theme's template is entitled to its own — and both are filterable. Returning
`get_option( 'posts_per_page' )` from `traktivity_archive_posts_per_page` hands
the decision back to the site.

## Testing

PHPUnit 272 passing, 604 assertions. Three new tests cover the page size being
applied, being filterable, and being left alone when the template is off.

`composer run lint && composer run analyse` clean, package check and JS lint pass.
