### PR TITLE
List the template parts, so they can actually be placed

### DIFF
--- a/templates.traktivity.php
+++ b/templates.traktivity.php
@@ -42,6 +42,7 @@ class Traktivity_Templates {
 	public static function init(): void {
 		add_action( 'init', array( __CLASS__, 'register_templates' ), 20 );
 		add_filter( 'get_block_template', array( __CLASS__, 'provide_template_part' ), 10, 3 );
+		add_filter( 'get_block_templates', array( __CLASS__, 'list_template_parts' ), 10, 3 );
 		add_action( 'pre_get_posts', array( __CLASS__, 'shape_archive_query' ) );
 	}
 
@@ -439,6 +440,88 @@ class Traktivity_Templates {
 	}
 
 	/**
+	 * Build the WP_Block_Template object for one of our parts.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param string $slug Part slug.
+	 * @param array  $part Part definition.
+	 *
+	 * @return WP_Block_Template|null Null when the markup is unreadable.
+	 */
+	private static function build_part( string $slug, array $part ) {
+		$content = self::content( $part['file'] );
+
+		if ( '' === $content ) {
+			return null;
+		}
+
+		$template                 = new WP_Block_Template();
+		$template->id             = self::part_id( $slug );
+		$template->theme          = get_stylesheet();
+		$template->slug           = $slug;
+		$template->type           = 'wp_template_part';
+		$template->area           = 'uncategorized';
+		$template->source         = 'plugin';
+		$template->status         = 'publish';
+		$template->has_theme_file = false;
+		$template->is_custom      = true;
+		$template->title          = $part['title'];
+		$template->description    = $part['description'];
+		$template->content        = $content;
+
+		return $template;
+	}
+
+	/**
+	 * Add our parts to the lists the editor reads.
+	 *
+	 * The single-template filter answers for one ID, which is enough to render
+	 * a part and to open it from a direct link, and not enough for anything to
+	 * find it: the Site Editor's parts list and the Template Part block's
+	 * picker both read the collection rather than asking for IDs one at a
+	 * time. Without this the parts are editable but unplaceable, which makes
+	 * them close to useless.
+	 *
+	 * Anything already in the list wins, so a part the site owner has edited
+	 * and saved is not shadowed by ours.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param WP_Block_Template[] $query_result  Templates found so far.
+	 * @param array               $query         Arguments the caller asked for.
+	 * @param string              $template_type Either wp_template or wp_template_part.
+	 *
+	 * @return WP_Block_Template[]
+	 */
+	public static function list_template_parts( $query_result, $query, $template_type ) {
+		if ( 'wp_template_part' !== $template_type || ! wp_is_block_theme() ) {
+			return $query_result;
+		}
+
+		$existing = wp_list_pluck( (array) $query_result, 'slug' );
+		$wanted   = isset( $query['slug__in'] ) ? (array) $query['slug__in'] : array();
+
+		foreach ( self::available_parts() as $slug => $part ) {
+			if ( in_array( $slug, $existing, true ) || ! self::is_enabled( $slug ) ) {
+				continue;
+			}
+
+			if ( ! empty( $wanted ) && ! in_array( $slug, $wanted, true ) ) {
+				continue;
+			}
+
+			$template = self::build_part( $slug, $part );
+
+			if ( null !== $template ) {
+				$query_result[] = $template;
+			}
+		}
+
+		return $query_result;
+	}
+
+	/**
 	 * Hand back one of our parts when nothing else claims that ID.
 	 *
 	 * @since 3.1.0
@@ -459,27 +542,9 @@ class Traktivity_Templates {
 				continue;
 			}
 
-			$content = self::content( $part['file'] );
+			$template = self::build_part( $slug, $part );
 
-			if ( '' === $content ) {
-				return $block_template;
-			}
-
-			$template                 = new WP_Block_Template();
-			$template->id             = $id;
-			$template->theme          = get_stylesheet();
-			$template->slug           = $slug;
-			$template->type           = 'wp_template_part';
-			$template->area           = 'uncategorized';
-			$template->source         = 'plugin';
-			$template->status         = 'publish';
-			$template->has_theme_file = false;
-			$template->is_custom      = true;
-			$template->title          = $part['title'];
-			$template->description    = $part['description'];
-			$template->content        = $content;
-
-			return $template;
+			return null === $template ? $block_template : $template;
 		}
 
 		return $block_template;

--- a/tests/php/TemplatePartsTest.php
+++ b/tests/php/TemplatePartsTest.php
@@ -155,6 +155,94 @@ class TemplatePartsTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Enabled parts appear in the lists the editor reads.
+	 *
+	 * Answering for a single ID is enough to render a part and to open it from
+	 * a direct link, and not enough for anything to find it: the Site Editor's
+	 * parts list and the Template Part block's picker both read the
+	 * collection. Without this the parts are editable but unplaceable.
+	 */
+	public function test_enabled_parts_are_listed() {
+		if ( ! $this->use_block_theme() ) {
+			$this->markTestSkipped( 'No block theme available to switch to.' );
+		}
+
+		$this->enable( array( 'traktivity-watch-stats', 'traktivity-series-index' ) );
+
+		$listed = Traktivity_Templates::list_template_parts( array(), array(), 'wp_template_part' );
+		$slugs  = wp_list_pluck( $listed, 'slug' );
+
+		$this->assertContains( 'traktivity-watch-stats', $slugs );
+		$this->assertContains( 'traktivity-series-index', $slugs );
+		$this->assertNotContains( 'traktivity-recent-watches', $slugs, 'A part that is off should not be listed.' );
+	}
+
+	/**
+	 * A part already in the list is not added a second time.
+	 *
+	 * Once someone edits one, WordPress has its own copy, and ours must not
+	 * shadow it.
+	 */
+	public function test_existing_parts_are_not_duplicated() {
+		if ( ! $this->use_block_theme() ) {
+			$this->markTestSkipped( 'No block theme available to switch to.' );
+		}
+
+		$this->enable( array( 'traktivity-watch-stats' ) );
+
+		$saved         = new WP_Block_Template();
+		$saved->slug   = 'traktivity-watch-stats';
+		$saved->source = 'custom';
+
+		$listed = Traktivity_Templates::list_template_parts( array( $saved ), array(), 'wp_template_part' );
+		$slugs  = wp_list_pluck( $listed, 'slug' );
+
+		$this->assertSame( 1, count( array_keys( $slugs, 'traktivity-watch-stats', true ) ) );
+		$this->assertSame( 'custom', $listed[0]->source );
+	}
+
+	/**
+	 * A slug filter is honoured, so a targeted lookup stays targeted.
+	 */
+	public function test_listing_honours_a_slug_filter() {
+		if ( ! $this->use_block_theme() ) {
+			$this->markTestSkipped( 'No block theme available to switch to.' );
+		}
+
+		$this->enable( array( 'traktivity-watch-stats', 'traktivity-series-index' ) );
+
+		$listed = Traktivity_Templates::list_template_parts(
+			array(),
+			array( 'slug__in' => array( 'traktivity-series-index' ) ),
+			'wp_template_part'
+		);
+
+		$this->assertSame( array( 'traktivity-series-index' ), wp_list_pluck( $listed, 'slug' ) );
+	}
+
+	/**
+	 * Whole templates and classic themes are left alone.
+	 */
+	public function test_listing_leaves_other_requests_alone() {
+		$this->enable( array( 'traktivity-watch-stats' ) );
+
+		$this->assertSame( array(), Traktivity_Templates::list_template_parts( array(), array(), 'wp_template' ) );
+
+		add_filter( 'wp_is_block_theme', '__return_false' );
+		$classic = Traktivity_Templates::list_template_parts( array(), array(), 'wp_template_part' );
+		remove_filter( 'wp_is_block_theme', '__return_false' );
+
+		$this->assertSame( array(), $classic );
+	}
+
+	/**
+	 * The listing filter is wired up.
+	 */
+	public function test_listing_filter_is_hooked() {
+		$this->assertNotFalse( has_filter( 'get_block_templates', array( 'Traktivity_Templates', 'list_template_parts' ) ) );
+	}
+
+	/**
 	 * A part that is switched off is not provided.
 	 */
 	public function test_disabled_part_is_not_provided() {


### PR DESCRIPTION
Part of #683. Found browsing the Site Editor during smoke testing.

## The problem

The template parts from #699 were **editable but unplaceable**, which makes them
close to useless.

Answering the `get_block_template` filter is enough to render a part and to open
one from a direct link, which is what the dashboard's "Preview and edit" offers,
so both of those worked and looked fine.

But the Site Editor's parts list and core's Template Part block picker read the
*collection*, and the collection never knew about them:

```
/wp/v2/template-parts  ->  7 results
   vertical-header, footer-columns, footer-newsletter,
   header-large-title, footer, sidebar, header
   traktivity parts: none
```

#698's card copy tells people to place a part by adding a Template Part block.
That block could not offer them one.

## The fix

Filter `get_block_templates` as well, so the parts appear in both lists:

```
/wp/v2/template-parts  ->  12 results
   ...the theme's seven, plus:
   traktivity-recent-watches   "Recently watched"        source: plugin
   traktivity-latest-watch     "Last watched, large"     source: plugin
   traktivity-watch-stats      "Watch totals"            source: plugin
   traktivity-series-index     "Every series, A to Z"    source: plugin
   traktivity-recent-compact   "Recently watched, compact" source: plugin
```

All five now show in the Site Editor's parts list under their own titles,
verified in the browser.

Details:

- **Anything already in the list wins**, so a part someone has edited and saved
  isn't shadowed by ours.
- **A slug filter is honoured**, so a targeted lookup stays targeted rather than
  being handed all five.
- **Only enabled parts are listed**, matching the single-ID filter.
- Building the `WP_Block_Template` moved into one place, since answering for an
  ID and listing the collection have to describe the same part.

## Testing

PHPUnit 277 passing, 613 assertions. Five new tests: enabled parts listed and
disabled ones not, existing parts not duplicated, the slug filter honoured, whole
templates and classic themes left alone, and the filter being hooked.

`composer run lint && composer run analyse` clean, package check passes.
