### PR TITLE
Place blocks and parts the way Jetpack's subscribe placements do

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Plugin PHP sits at the root, named `<area>.traktivity.php`:
 | `helpers.traktivity.php` | Shared accessors for event and show data |
 | `blocks.traktivity.php` | Block registration |
 | `templates.traktivity.php` | Block templates and template parts |
+| `placements.traktivity.php` | Where the plugin puts its own blocks and parts |
 | `admin.traktivity.php` | Dashboard page, admin only |
 | `widgets/` | The legacy classic widget |
 | `src/` | Dashboard React app, and block sources under `src/blocks/` |
@@ -38,10 +39,14 @@ Those names look unusual because they are baked into the wordpress.org SVN
 layout. `phpcs.xml.dist` turns `WordPress.Files.FileName` off deliberately for
 that reason. Follow the pattern rather than fixing it.
 
-**Do not edit `Traktivity::load_plugin()` for 3.1.0 work.** Every file that
-milestone needs is already required, including the ones still empty. The same
-goes for the `files` allowlist in `package.json`. Both were wired up front
-precisely so parallel branches don't collide on them.
+**Think twice before editing `Traktivity::load_plugin()` or the `files`
+allowlist in `package.json`.** Both were wired up front for the 3.1.0 files so
+parallel branches would not collide on them, so a branch that only fills in an
+already-required file must leave them alone.
+
+A genuinely new file is the exception, and it does have to be added to both. Say
+so in the pull request when you do, since it is the one place two branches can
+still conflict.
 
 ## Blocks
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "core.traktivity.php",
     "cpt.traktivity.php",
     "helpers.traktivity.php",
+    "placements.traktivity.php",
     "rest.traktivity.php",
     "stats.traktivity.php",
     "templates.traktivity.php",

--- a/placements.traktivity.php
+++ b/placements.traktivity.php
@@ -1,0 +1,297 @@
+<?php
+/**
+ * Where the plugin puts its own blocks and parts on the front end.
+ *
+ * A plugin cannot rely on core's Template Part block to place anything it
+ * provides. That block resolves a part by querying wp_template_part posts and
+ * then falling back to a theme file under parts/; it never asks
+ * get_block_template(), so a part a plugin answers for is invisible to it. A
+ * part registered the way templates.traktivity.php registers one is therefore
+ * editable and previewable, and cannot be placed by hand.
+ *
+ * So the plugin places things itself, the two ways Jetpack's subscribe
+ * placements do:
+ *
+ * - Hooked blocks, for a self-contained block anchored to another block in a
+ *   template. The block lands in the template, and the site owner can move or
+ *   delete it in the Site Editor and that sticks. Classic themes have no
+ *   templates to hook into, so those fall back to the_content.
+ * - block_template_part() called at a PHP hook, for the parts whose markup is a
+ *   query loop rather than one block. Hooked blocks insert a single registered
+ *   block, so a loop cannot travel that way.
+ *
+ * Every placement is off until switched on, same as the templates.
+ *
+ * @package Traktivity
+ */
+
+declare( strict_types = 1 );
+
+defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
+
+/**
+ * Put Traktivity's blocks and parts on the front end.
+ *
+ * @since 3.1.0
+ */
+class Traktivity_Placements {
+
+	/**
+	 * Hook everything up.
+	 *
+	 * @since 3.1.0
+	 */
+	public static function init(): void {
+		add_action( 'init', array( __CLASS__, 'register_placements' ), 30 );
+	}
+
+	/**
+	 * The placements the plugin offers.
+	 *
+	 * `block` placements travel as hooked blocks and name a registered block,
+	 * an anchor to sit against, and where relative to it. `part` placements are
+	 * rendered by the plugin at the named action, because their markup is a
+	 * query loop rather than a single block.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public static function available(): array {
+		return array(
+			'traktivity-totals-on-archive'    => array(
+				'type'        => 'block',
+				'block'       => 'traktivity/watch-stats',
+				'anchor'      => 'core/query',
+				'position'    => 'before',
+				'context'     => 'archive-traktivity_event',
+				'title'       => __( 'Totals above the archive', 'traktivity' ),
+				'description' => __( 'Hours, entries, episodes, films and series, at the top of your archive.', 'traktivity' ),
+			),
+			'traktivity-latest-on-archive'    => array(
+				'type'        => 'block',
+				'block'       => 'traktivity/latest-watch',
+				'anchor'      => 'core/query',
+				'position'    => 'before',
+				'context'     => 'archive-traktivity_event',
+				'title'       => __( 'Last watched, above the archive', 'traktivity' ),
+				'description' => __( 'The most recent thing you watched, shown large above the list.', 'traktivity' ),
+			),
+			'traktivity-series-after-entry'   => array(
+				'type'        => 'block',
+				'block'       => 'traktivity/top-shows',
+				'anchor'      => 'core/post-content',
+				'position'    => 'after',
+				'context'     => 'single-traktivity_event',
+				'title'       => __( 'Series you watch most, after an entry', 'traktivity' ),
+				'description' => __( 'A grid of your most-watched series at the end of every entry.', 'traktivity' ),
+			),
+			'traktivity-recent-in-footer'     => array(
+				'type'        => 'part',
+				'part'        => 'traktivity-recent-compact',
+				'action'      => 'wp_footer',
+				'title'       => __( 'Recently watched, in the footer', 'traktivity' ),
+				'description' => __( 'A short list of your latest entries at the bottom of every page.', 'traktivity' ),
+			),
+			'traktivity-recent-after-archive' => array(
+				'type'        => 'part',
+				'part'        => 'traktivity-recent-watches',
+				'action'      => 'wp_footer',
+				'title'       => __( 'Recently watched, as a grid', 'traktivity' ),
+				'description' => __( 'The last few things you watched, as a grid of cards below the page.', 'traktivity' ),
+			),
+		);
+	}
+
+	/**
+	 * Whether a placement is switched on.
+	 *
+	 * Shares the option with the templates, so the settings screen reads and
+	 * writes one thing.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param string $slug Placement slug.
+	 *
+	 * @return bool
+	 */
+	public static function is_enabled( string $slug ): bool {
+		return Traktivity_Templates::is_enabled( $slug );
+	}
+
+	/**
+	 * Wire up whichever placements are switched on.
+	 *
+	 * @since 3.1.0
+	 */
+	public static function register_placements(): void {
+		foreach ( self::available() as $slug => $placement ) {
+			if ( ! self::is_enabled( $slug ) ) {
+				continue;
+			}
+
+			if ( 'part' === $placement['type'] ) {
+				self::hook_part( $placement );
+				continue;
+			}
+
+			self::hook_block( $slug, $placement );
+		}
+	}
+
+	/**
+	 * Render a part at the action its placement names.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param array $placement Placement definition.
+	 */
+	private static function hook_part( array $placement ): void {
+		add_action(
+			$placement['action'],
+			static function () use ( $placement ) {
+				self::render_part( $placement['part'] );
+			}
+		);
+	}
+
+	/**
+	 * Print one of the plugin's parts.
+	 *
+	 * Named rather than inline so it can be called directly, including from a
+	 * test that does not want to fire a whole page's worth of wp_footer.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param string $part Part slug.
+	 */
+	public static function render_part( string $part ): void {
+		if ( ! wp_is_block_theme() ) {
+			return;
+		}
+
+		echo '<div class="traktivity-placement traktivity-placement--' . esc_attr( $part ) . '">';
+		block_template_part( $part );
+		echo '</div>';
+	}
+
+	/**
+	 * Put a block into a template, or after the content on a classic theme.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param string $slug      Placement slug.
+	 * @param array  $placement Placement definition.
+	 */
+	private static function hook_block( string $slug, array $placement ): void {
+		if ( ! wp_is_block_theme() ) {
+			self::hook_block_for_classic_theme( $placement );
+			return;
+		}
+
+		add_filter(
+			'hooked_block_types',
+			static function ( $hooked_blocks, $relative_position, $anchor_block, $context ) use ( $placement ) {
+				if (
+					$anchor_block === $placement['anchor']
+					&& $relative_position === $placement['position']
+					&& self::is_context( $context, $placement['context'] )
+				) {
+					$hooked_blocks[] = $placement['block'];
+				}
+
+				return $hooked_blocks;
+			},
+			10,
+			4
+		);
+
+		unset( $slug );
+	}
+
+	/**
+	 * Append a block after the content, for themes with no templates to hook.
+	 *
+	 * Only the single-entry placements have a sensible classic-theme home. An
+	 * archive placement has nowhere to go without a template, so it is skipped
+	 * rather than dropped somewhere arbitrary.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param array $placement Placement definition.
+	 */
+	private static function hook_block_for_classic_theme( array $placement ): void {
+		if ( 'single-traktivity_event' !== $placement['context'] ) {
+			return;
+		}
+
+		add_filter(
+			'the_content',
+			static function ( $content ) use ( $placement ) {
+				if ( ! is_singular( 'traktivity_event' ) || ! in_the_loop() || ! is_main_query() ) {
+					return $content;
+				}
+
+				return $content . do_blocks( '<!-- wp:' . $placement['block'] . ' /-->' );
+			},
+			100
+		);
+	}
+
+	/**
+	 * Whether the template a hooked block is being offered to is the one wanted.
+	 *
+	 * A template part or pattern arrives here too, and an array turns up on
+	 * themes that do not hand over a WP_Block_Template at all, so the queried
+	 * template is checked by slug and the array case falls back to asking
+	 * WordPress what is being viewed.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param WP_Block_Template|WP_Post|array $context The template the anchor block belongs to.
+	 * @param string                          $wanted  Template slug the placement asked for.
+	 *
+	 * @return bool
+	 */
+	private static function is_context( $context, string $wanted ): bool {
+		if ( $context instanceof WP_Block_Template ) {
+			return $context->slug === $wanted;
+		}
+
+		if ( is_array( $context ) ) {
+			return 'single-traktivity_event' === $wanted
+				? is_singular( 'traktivity_event' )
+				: is_post_type_archive( 'traktivity_event' );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Everything the settings screen needs to describe the placements.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public static function for_settings(): array {
+		$entries = array();
+
+		foreach ( self::available() as $slug => $placement ) {
+			$entries[] = array(
+				'slug'          => $slug,
+				'type'          => 'placement',
+				'editSlug'      => 'part' === $placement['type'] ? $placement['part'] : '',
+				'editType'      => 'part' === $placement['type'] ? 'wp_template_part' : '',
+				'title'         => $placement['title'],
+				'description'   => $placement['description'],
+				'enabled'       => self::is_enabled( $slug ),
+				'themeProvides' => false,
+			);
+		}
+
+		return $entries;
+	}
+}
+
+Traktivity_Placements::init();

--- a/placements.traktivity.php
+++ b/placements.traktivity.php
@@ -49,7 +49,8 @@ class Traktivity_Placements {
 	 * The placements the plugin offers.
 	 *
 	 * `block` placements travel as hooked blocks and name a registered block,
-	 * an anchor to sit against, and where relative to it. `part` placements are
+	 * an anchor to sit against, where relative to it, and any attributes the
+	 * inserted block needs. `part` placements are
 	 * rendered by the plugin at the named action, because their markup is a
 	 * query loop rather than a single block.
 	 *
@@ -65,6 +66,7 @@ class Traktivity_Placements {
 				'anchor'      => 'core/query',
 				'position'    => 'before',
 				'context'     => 'archive-traktivity_event',
+				'attributes'  => array( 'align' => 'wide' ),
 				'title'       => __( 'Totals above the archive', 'traktivity' ),
 				'description' => __( 'Hours, entries, episodes, films and series, at the top of your archive.', 'traktivity' ),
 			),
@@ -74,6 +76,7 @@ class Traktivity_Placements {
 				'anchor'      => 'core/query',
 				'position'    => 'before',
 				'context'     => 'archive-traktivity_event',
+				'attributes'  => array( 'align' => 'wide' ),
 				'title'       => __( 'Last watched, above the archive', 'traktivity' ),
 				'description' => __( 'The most recent thing you watched, shown large above the list.', 'traktivity' ),
 			),
@@ -83,6 +86,7 @@ class Traktivity_Placements {
 				'anchor'      => 'core/post-content',
 				'position'    => 'after',
 				'context'     => 'single-traktivity_event',
+				'attributes'  => array(),
 				'title'       => __( 'Series you watch most, after an entry', 'traktivity' ),
 				'description' => __( 'A grid of your most-watched series at the end of every entry.', 'traktivity' ),
 			),
@@ -206,6 +210,34 @@ class Traktivity_Placements {
 			4
 		);
 
+		if ( empty( $placement['attributes'] ) ) {
+			return;
+		}
+
+		/*
+		 * hooked_block_types only names a block, so the one that lands has no
+		 * attributes. The archive placements need align=wide, which the
+		 * template used to set by hand; without it a content-width band sits
+		 * above a wide grid.
+		 */
+		add_filter(
+			'hooked_block_' . $placement['block'],
+			static function ( $hooked_block, $hooked_block_type, $relative_position, $anchor_block ) use ( $placement ) {
+				if ( $anchor_block['blockName'] !== $placement['anchor'] || $relative_position !== $placement['position'] ) {
+					return $hooked_block;
+				}
+
+				$hooked_block['attrs'] = array_merge(
+					isset( $hooked_block['attrs'] ) ? (array) $hooked_block['attrs'] : array(),
+					$placement['attributes']
+				);
+
+				return $hooked_block;
+			},
+			10,
+			4
+		);
+
 		unset( $slug );
 	}
 
@@ -241,14 +273,14 @@ class Traktivity_Placements {
 	/**
 	 * Whether the template a hooked block is being offered to is the one wanted.
 	 *
-	 * A template part or pattern arrives here too, and an array turns up on
-	 * themes that do not hand over a WP_Block_Template at all, so the queried
-	 * template is checked by slug and the array case falls back to asking
-	 * WordPress what is being viewed.
+	 * An array turns up on themes that do not hand over a WP_Block_Template at
+	 * all, so that case falls back to asking WordPress what is being viewed.
+	 * A WP_Post arrives for a navigation menu, which none of these placements
+	 * anchors to, so anything that is neither is simply not ours.
 	 *
 	 * @since 3.1.0
 	 *
-	 * @param WP_Block_Template|WP_Post|array $context The template the anchor block belongs to.
+	 * @param WP_Block_Template|WP_Post|array $context The template, part or menu the anchor block belongs to.
 	 * @param string                          $wanted  Template slug the placement asked for.
 	 *
 	 * @return bool

--- a/src/components/templates/TemplateCard.js
+++ b/src/components/templates/TemplateCard.js
@@ -82,7 +82,16 @@ export default function TemplateCard( {
 					{ template.type === 'wp_template_part' && (
 						<p className="traktivity-template-card__note">
 							{ __(
-								'Nothing places this for you. Switch it on, then add a Template Part block wherever you want it.',
+								'This is the layout a placement below uses. Editing it here changes wherever that placement appears.',
+								'traktivity'
+							) }
+						</p>
+					) }
+
+					{ template.type === 'placement' && (
+						<p className="traktivity-template-card__note">
+							{ __(
+								'Traktivity puts this on the page for you. You can move or remove it afterwards in the Site Editor.',
 								'traktivity'
 							) }
 						</p>

--- a/src/components/templates/TemplateSettings.js
+++ b/src/components/templates/TemplateSettings.js
@@ -33,9 +33,24 @@ function editUrlFor( template ) {
 		return '';
 	}
 
+	/*
+	 * A placement has no template of its own. The ones built from a part point
+	 * at that part, so "Preview and edit" opens the layout being placed; the
+	 * ones that hook a block have nothing to open until the block is in a
+	 * template, so they get no link.
+	 */
+	const postType =
+		template.type === 'placement' ? template.editType : template.type;
+	const slug =
+		template.type === 'placement' ? template.editSlug : template.slug;
+
+	if ( ! postType || ! slug ) {
+		return '';
+	}
+
 	return addQueryArgs( settings.siteEditorUrl, {
-		postType: template.type,
-		postId: `${ settings.themeStylesheet }//${ template.slug }`,
+		postType,
+		postId: `${ settings.themeStylesheet }//${ slug }`,
 		canvas: 'edit',
 	} );
 }

--- a/templates.traktivity.php
+++ b/templates.traktivity.php
@@ -302,27 +302,39 @@ class Traktivity_Templates {
 				'title'       => __( 'Recently watched', 'traktivity' ),
 				'description' => __( 'The last few things you watched, as a grid of cards.', 'traktivity' ),
 			),
-			'traktivity-latest-watch'   => array(
-				'file'        => 'parts/traktivity-latest-watch.html',
-				'title'       => __( 'Last watched, large', 'traktivity' ),
-				'description' => __( 'The most recent thing you watched, shown large.', 'traktivity' ),
-			),
-			'traktivity-watch-stats'    => array(
-				'file'        => 'parts/traktivity-watch-stats.html',
-				'title'       => __( 'Watch totals', 'traktivity' ),
-				'description' => __( 'Hours, entries, episodes, films and series, as a band.', 'traktivity' ),
-			),
-			'traktivity-series-index'   => array(
-				'file'        => 'parts/traktivity-series-index.html',
-				'title'       => __( 'Every series, A to Z', 'traktivity' ),
-				'description' => __( 'A full index of every series you have logged.', 'traktivity' ),
-			),
 			'traktivity-recent-compact' => array(
 				'file'        => 'parts/traktivity-recent-compact.html',
 				'title'       => __( 'Recently watched, compact', 'traktivity' ),
 				'description' => __( 'A short text list, for a sidebar or a footer.', 'traktivity' ),
 			),
 		);
+	}
+
+	/**
+	 * Whether a part is needed by something that is switched on.
+	 *
+	 * A part is not switched on in its own right. It exists to give a
+	 * placement its markup, so it is provided exactly when a placement using
+	 * it is on. One switch per thing the site owner actually sees.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param string $slug Part slug.
+	 *
+	 * @return bool
+	 */
+	public static function part_is_needed( string $slug ): bool {
+		foreach ( Traktivity_Placements::available() as $placement_slug => $placement ) {
+			if (
+				'part' === $placement['type']
+				&& $placement['part'] === $slug
+				&& Traktivity_Placements::is_enabled( $placement_slug )
+			) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**
@@ -379,18 +391,11 @@ class Traktivity_Templates {
 			);
 		}
 
-		foreach ( self::available_parts() as $slug => $part ) {
-			$entries[] = array(
-				'slug'          => $slug,
-				'type'          => 'wp_template_part',
-				'title'         => $part['title'],
-				'description'   => $part['description'],
-				'enabled'       => self::is_enabled( $slug ),
-				'themeProvides' => false,
-			);
-		}
-
-		return $entries;
+		/*
+		 * Parts are absent on purpose. One is never switched on by itself; it
+		 * backs a placement, and the placement's card links to it for editing.
+		 */
+		return array_merge( $entries, Traktivity_Placements::for_settings() );
 	}
 
 	/**
@@ -406,7 +411,10 @@ class Traktivity_Templates {
 	 * @return array The stored value.
 	 */
 	public static function save_enabled( array $enabled ): array {
-		$known = array_merge( array_keys( self::available() ), array_keys( self::available_parts() ) );
+		$known = array_merge(
+			array_keys( self::available() ),
+			array_keys( Traktivity_Placements::available() )
+		);
 		$clean = array();
 
 		foreach ( $known as $slug ) {
@@ -503,7 +511,7 @@ class Traktivity_Templates {
 		$wanted   = isset( $query['slug__in'] ) ? (array) $query['slug__in'] : array();
 
 		foreach ( self::available_parts() as $slug => $part ) {
-			if ( in_array( $slug, $existing, true ) || ! self::is_enabled( $slug ) ) {
+			if ( in_array( $slug, $existing, true ) || ! self::part_is_needed( $slug ) ) {
 				continue;
 			}
 
@@ -538,7 +546,7 @@ class Traktivity_Templates {
 		}
 
 		foreach ( self::available_parts() as $slug => $part ) {
-			if ( self::part_id( $slug ) !== $id || ! self::is_enabled( $slug ) ) {
+			if ( self::part_id( $slug ) !== $id || ! self::part_is_needed( $slug ) ) {
 				continue;
 			}
 

--- a/templates/archive-traktivity_event.html
+++ b/templates/archive-traktivity_event.html
@@ -6,8 +6,6 @@
 	<h1 class="wp-block-heading">{{ARCHIVE_TITLE}}</h1>
 	<!-- /wp:heading -->
 
-	<!-- wp:traktivity/watch-stats {"align":"wide"} /-->
-
 	<!-- wp:query {"queryId":1,"query":{"perPage":24,"pages":0,"offset":0,"postType":"traktivity_event","order":"desc","orderBy":"date","inherit":true},"align":"wide","layout":{"type":"default"}} -->
 	<div class="wp-block-query alignwide">
 		<!-- wp:post-template {"layout":{"type":"grid","columnCount":4}} -->

--- a/templates/parts/traktivity-latest-watch.html
+++ b/templates/parts/traktivity-latest-watch.html
@@ -1,5 +1,0 @@
-<!-- wp:heading -->
-<h2 class="wp-block-heading">{{LATEST_TITLE}}</h2>
-<!-- /wp:heading -->
-
-<!-- wp:traktivity/latest-watch /-->

--- a/templates/parts/traktivity-series-index.html
+++ b/templates/parts/traktivity-series-index.html
@@ -1,5 +1,0 @@
-<!-- wp:heading -->
-<h2 class="wp-block-heading">{{INDEX_TITLE}}</h2>
-<!-- /wp:heading -->
-
-<!-- wp:traktivity/top-shows {"number":0,"orderby":"name","columns":4} /-->

--- a/templates/parts/traktivity-watch-stats.html
+++ b/templates/parts/traktivity-watch-stats.html
@@ -1,1 +1,0 @@
-<!-- wp:traktivity/watch-stats {"align":"wide"} /-->

--- a/tests/js/template-settings.test.js
+++ b/tests/js/template-settings.test.js
@@ -23,11 +23,13 @@ const TEMPLATE = {
 	themeProvides: false,
 };
 
-const PART = {
-	slug: 'traktivity-watch-stats',
-	type: 'wp_template_part',
-	title: 'Watch totals',
-	description: 'Hours, entries, episodes, films and series, as a band.',
+const PLACEMENT = {
+	slug: 'traktivity-totals-on-archive',
+	type: 'placement',
+	editSlug: '',
+	editType: '',
+	title: 'Totals above the archive',
+	description: 'Hours, entries, episodes, films and series, at the top of your archive.',
 	enabled: false,
 	themeProvides: false,
 };
@@ -43,7 +45,7 @@ function withSettings( overrides = {} ) {
 		hasEvents: true,
 		themeStylesheet: 'twentytwentyfour',
 		siteEditorUrl: 'http://example.org/wp-admin/site-editor.php',
-		templates: [ TEMPLATE, PART ],
+		templates: [ TEMPLATE, PLACEMENT ],
 		...overrides,
 	} );
 }
@@ -68,16 +70,16 @@ describe( 'TemplateSettings', () => {
 		render( <TemplateSettings /> );
 
 		expect( screen.getByText( 'Everything watched' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Watch totals' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Totals above the archive' ) ).toBeInTheDocument();
 	} );
 
-	it( 'says a template part has to be placed by hand', () => {
+	it( 'says the plugin does the placing, and it can be moved after', () => {
 		withSettings();
 
 		render( <TemplateSettings /> );
 
 		expect(
-			screen.getByText( /add a Template Part block wherever you want it/ )
+			screen.getByText( /Traktivity puts this on the page for you/ )
 		).toBeInTheDocument();
 	} );
 
@@ -121,7 +123,7 @@ describe( 'TemplateSettings', () => {
 	it( 'saves a change', async () => {
 		withSettings();
 		apiFetch.mockResolvedValue( {
-			templates: [ { ...TEMPLATE, enabled: true }, PART ],
+			templates: [ { ...TEMPLATE, enabled: true }, PLACEMENT ],
 		} );
 
 		render( <TemplateSettings /> );
@@ -135,7 +137,7 @@ describe( 'TemplateSettings', () => {
 					data: {
 						enabled: {
 							'archive-traktivity_event': true,
-							'traktivity-watch-stats': false,
+							'traktivity-totals-on-archive': false,
 						},
 					},
 				} )
@@ -160,7 +162,7 @@ describe( 'TemplateSettings', () => {
 	it( 'only offers an edit link once the change is saved', async () => {
 		withSettings();
 		apiFetch.mockResolvedValue( {
-			templates: [ { ...TEMPLATE, enabled: true }, PART ],
+			templates: [ { ...TEMPLATE, enabled: true }, PLACEMENT ],
 		} );
 
 		render( <TemplateSettings /> );

--- a/tests/js/template-settings.test.js
+++ b/tests/js/template-settings.test.js
@@ -29,7 +29,8 @@ const PLACEMENT = {
 	editSlug: '',
 	editType: '',
 	title: 'Totals above the archive',
-	description: 'Hours, entries, episodes, films and series, at the top of your archive.',
+	description:
+		'Hours, entries, episodes, films and series, at the top of your archive.',
 	enabled: false,
 	themeProvides: false,
 };
@@ -70,7 +71,9 @@ describe( 'TemplateSettings', () => {
 		render( <TemplateSettings /> );
 
 		expect( screen.getByText( 'Everything watched' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Totals above the archive' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( 'Totals above the archive' )
+		).toBeInTheDocument();
 	} );
 
 	it( 'says the plugin does the placing, and it can be moved after', () => {

--- a/tests/package/verify-package.mjs
+++ b/tests/package/verify-package.mjs
@@ -123,7 +123,7 @@ for ( const required of [
 	'templates/taxonomy-trakt_show.html',
 	'templates/taxonomy-traktivity.html',
 	'templates/parts/traktivity-recent-watches.html',
-	'templates/parts/traktivity-watch-stats.html',
+	'templates/parts/traktivity-recent-compact.html',
 ] ) {
 	check( has( required ), `ships ${ required }` );
 }

--- a/tests/php/PlacementsTest.php
+++ b/tests/php/PlacementsTest.php
@@ -193,6 +193,39 @@ class PlacementsTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * An archive placement asks for the width the archive is laid out at.
+	 *
+	 * The hooked_block_types filter only names a block, so the one that lands
+	 * carries no attributes. Without this a content-width band sits above a
+	 * wide grid, which the template used to avoid by setting align by hand.
+	 */
+	public function test_archive_placement_is_wide() {
+		if ( ! $this->use_block_theme() ) {
+			$this->markTestSkipped( 'No block theme available to switch to.' );
+		}
+
+		$this->enable( array( 'traktivity-totals-on-archive' ) );
+		Traktivity_Placements::register_placements();
+
+		// Built from the block name, the way core builds it, slash and dash included.
+		$block = 'traktivity/watch-stats';
+		$hook  = 'hooked_block_' . $block;
+
+		$hooked = apply_filters(
+			$hook,
+			array(
+				'blockName' => $block,
+				'attrs'     => array(),
+			),
+			$block,
+			'before',
+			array( 'blockName' => 'core/query' )
+		);
+
+		$this->assertSame( 'wide', $hooked['attrs']['align'] );
+	}
+
+	/**
 	 * A placement that is off hooks nothing.
 	 */
 	public function test_disabled_placement_hooks_nothing() {

--- a/tests/php/PlacementsTest.php
+++ b/tests/php/PlacementsTest.php
@@ -1,0 +1,317 @@
+<?php
+/**
+ * Tests for where the plugin puts its blocks and parts.
+ *
+ * @package Traktivity
+ */
+
+/**
+ * Placing blocks and parts on the front end.
+ *
+ * Core's Template Part block cannot resolve a part a plugin provides, so
+ * nothing here relies on it. Blocks travel as hooked blocks and parts are
+ * rendered by the plugin at an action, which is how Jetpack's subscribe
+ * placements work.
+ */
+class PlacementsTest extends WP_UnitTestCase {
+
+	/**
+	 * Theme active before a test switched it.
+	 *
+	 * @var string
+	 */
+	private $previous_theme = '';
+
+	/**
+	 * Start each test with nothing switched on.
+	 */
+	public function set_up() {
+		parent::set_up();
+		delete_option( Traktivity_Templates::OPTION );
+	}
+
+	/**
+	 * Put any switched theme back.
+	 */
+	public function tear_down() {
+		if ( '' !== $this->previous_theme ) {
+			switch_theme( $this->previous_theme );
+			$this->previous_theme = '';
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Switch to a block theme, since hooked blocks need templates.
+	 *
+	 * @return bool Whether a block theme was available.
+	 */
+	private function use_block_theme() {
+		if ( ! wp_get_theme( 'twentytwentyfour' )->exists() ) {
+			return false;
+		}
+
+		$this->previous_theme = get_stylesheet();
+		switch_theme( 'twentytwentyfour' );
+
+		return true;
+	}
+
+	/**
+	 * Switch placements on.
+	 *
+	 * @param string[] $slugs Placement slugs.
+	 */
+	private function enable( array $slugs ) {
+		update_option( Traktivity_Templates::OPTION, array_fill_keys( $slugs, true ) );
+	}
+
+	/**
+	 * Build the context a hooked block filter receives for one template.
+	 *
+	 * @param string $slug Template slug.
+	 *
+	 * @return WP_Block_Template
+	 */
+	private function template_context( $slug ) {
+		$template       = new WP_Block_Template();
+		$template->slug = $slug;
+		$template->type = 'wp_template';
+
+		return $template;
+	}
+
+	/**
+	 * Every placement names a block or a part that actually exists.
+	 *
+	 * A placement pointing at a renamed block would insert a block error, and
+	 * one pointing at a missing part would render nothing, neither of which
+	 * fails loudly on its own.
+	 *
+	 * @dataProvider data_placements
+	 *
+	 * @param string $slug      Placement slug.
+	 * @param array  $placement Placement definition.
+	 */
+	public function test_placement_targets_exist( $slug, $placement ) {
+		if ( 'block' === $placement['type'] ) {
+			$built = TRAKTIVITY__PLUGIN_DIR . 'build/blocks/' . str_replace( 'traktivity/', '', $placement['block'] );
+
+			$this->assertDirectoryExists( $built, "{$slug} names a block with no built directory." );
+			return;
+		}
+
+		$parts = Traktivity_Templates::available_parts();
+
+		$this->assertArrayHasKey( $placement['part'], $parts, "{$slug} names a part that does not exist." );
+		$this->assertNotSame( '', Traktivity_Templates::content( $parts[ $placement['part'] ]['file'] ) );
+	}
+
+	/**
+	 * Every placement the plugin offers.
+	 *
+	 * @return array<string, array{string, array}>
+	 */
+	public function data_placements() {
+		$cases = array();
+
+		foreach ( Traktivity_Placements::available() as $slug => $placement ) {
+			$cases[ $slug ] = array( $slug, $placement );
+		}
+
+		return $cases;
+	}
+
+	/**
+	 * Nothing is placed by default.
+	 */
+	public function test_nothing_is_enabled_by_default() {
+		foreach ( array_keys( Traktivity_Placements::available() ) as $slug ) {
+			$this->assertFalse( Traktivity_Placements::is_enabled( $slug ), "{$slug} is on by default." );
+		}
+	}
+
+	/**
+	 * An enabled block placement hooks its block against the right anchor.
+	 */
+	public function test_block_placement_hooks_its_block() {
+		if ( ! $this->use_block_theme() ) {
+			$this->markTestSkipped( 'No block theme available to switch to.' );
+		}
+
+		$this->enable( array( 'traktivity-series-after-entry' ) );
+		Traktivity_Placements::register_placements();
+
+		$hooked = apply_filters(
+			'hooked_block_types',
+			array(),
+			'after',
+			'core/post-content',
+			$this->template_context( 'single-traktivity_event' )
+		);
+
+		$this->assertContains( 'traktivity/top-shows', $hooked );
+	}
+
+	/**
+	 * A placement stays out of templates it was not meant for.
+	 */
+	public function test_block_placement_respects_its_context() {
+		if ( ! $this->use_block_theme() ) {
+			$this->markTestSkipped( 'No block theme available to switch to.' );
+		}
+
+		$this->enable( array( 'traktivity-series-after-entry' ) );
+		Traktivity_Placements::register_placements();
+
+		$wrong_template = apply_filters(
+			'hooked_block_types',
+			array(),
+			'after',
+			'core/post-content',
+			$this->template_context( 'single' )
+		);
+		$wrong_anchor   = apply_filters(
+			'hooked_block_types',
+			array(),
+			'after',
+			'core/post-title',
+			$this->template_context( 'single-traktivity_event' )
+		);
+		$wrong_position = apply_filters(
+			'hooked_block_types',
+			array(),
+			'before',
+			'core/post-content',
+			$this->template_context( 'single-traktivity_event' )
+		);
+
+		$this->assertNotContains( 'traktivity/top-shows', $wrong_template );
+		$this->assertNotContains( 'traktivity/top-shows', $wrong_anchor );
+		$this->assertNotContains( 'traktivity/top-shows', $wrong_position );
+	}
+
+	/**
+	 * A placement that is off hooks nothing.
+	 */
+	public function test_disabled_placement_hooks_nothing() {
+		if ( ! $this->use_block_theme() ) {
+			$this->markTestSkipped( 'No block theme available to switch to.' );
+		}
+
+		Traktivity_Placements::register_placements();
+
+		$hooked = apply_filters(
+			'hooked_block_types',
+			array(),
+			'after',
+			'core/post-content',
+			$this->template_context( 'single-traktivity_event' )
+		);
+
+		$this->assertNotContains( 'traktivity/top-shows', $hooked );
+	}
+
+	/**
+	 * A part placement renders itself at the action it names.
+	 */
+	public function test_part_placement_hooks_its_action() {
+		if ( ! $this->use_block_theme() ) {
+			$this->markTestSkipped( 'No block theme available to switch to.' );
+		}
+
+		$this->enable( array( 'traktivity-recent-in-footer' ) );
+		Traktivity_Placements::register_placements();
+
+		// The part is a query loop, so it needs something to loop over.
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'traktivity_event',
+				'post_status' => 'publish',
+				'post_title'  => 'Something Watched',
+			)
+		);
+		update_post_meta( $post_id, 'trakt_show_id', 1 );
+
+		$this->assertTrue( (bool) has_action( 'wp_footer' ) );
+
+		/*
+		 * The callback is called directly rather than by firing wp_footer,
+		 * which drags in the rest of the page and a core deprecation notice
+		 * that has nothing to do with this.
+		 */
+		ob_start();
+		Traktivity_Placements::render_part( 'traktivity-recent-compact' );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'traktivity-placement--traktivity-recent-compact', $output );
+		$this->assertStringContainsString( 'Something Watched', $output );
+	}
+
+	/**
+	 * A single-entry placement still lands on a classic theme.
+	 *
+	 * There are no templates to hook into, so it goes after the content
+	 * instead, the same fallback Jetpack uses for its post-end placement.
+	 */
+	public function test_classic_theme_falls_back_to_the_content() {
+		$this->enable( array( 'traktivity-series-after-entry' ) );
+
+		add_filter( 'wp_is_block_theme', '__return_false' );
+		Traktivity_Placements::register_placements();
+		remove_filter( 'wp_is_block_theme', '__return_false' );
+
+		$this->assertNotFalse( has_filter( 'the_content' ) );
+	}
+
+	/**
+	 * An archive placement is skipped on a classic theme.
+	 *
+	 * There is no sensible place for it without a template, and dropping it
+	 * into the content of every entry would be worse than leaving it out.
+	 */
+	public function test_archive_placement_is_skipped_on_a_classic_theme() {
+		$this->enable( array( 'traktivity-totals-on-archive' ) );
+
+		add_filter( 'wp_is_block_theme', '__return_false' );
+		Traktivity_Placements::register_placements();
+		remove_filter( 'wp_is_block_theme', '__return_false' );
+
+		$post_id = self::factory()->post->create( array( 'post_type' => 'traktivity_event' ) );
+
+		$this->assertStringNotContainsString(
+			'traktivity-stats',
+			apply_filters( 'the_content', 'Some content.' ),
+			'An archive placement has no classic-theme home.'
+		);
+		$this->assertNotSame( 0, $post_id );
+	}
+
+	/**
+	 * Every placement is described for the settings screen.
+	 */
+	public function test_placements_are_described() {
+		foreach ( Traktivity_Placements::for_settings() as $entry ) {
+			$this->assertNotSame( '', $entry['title'], "{$entry['slug']} has no title." );
+			$this->assertNotSame( '', $entry['description'], "{$entry['slug']} has no description." );
+			$this->assertSame( 'placement', $entry['type'] );
+		}
+	}
+
+	/**
+	 * Placements are stored in the same option as the templates.
+	 */
+	public function test_placements_share_the_templates_option() {
+		Traktivity_Templates::save_enabled( array( 'traktivity-totals-on-archive' => true ) );
+
+		$this->assertTrue( Traktivity_Placements::is_enabled( 'traktivity-totals-on-archive' ) );
+	}
+
+	/**
+	 * Registration is wired to init.
+	 */
+	public function test_registration_is_hooked() {
+		$this->assertNotFalse( has_action( 'init', array( 'Traktivity_Placements', 'register_placements' ) ) );
+	}
+}

--- a/tests/php/TemplatePartsTest.php
+++ b/tests/php/TemplatePartsTest.php
@@ -58,7 +58,23 @@ class TemplatePartsTest extends WP_UnitTestCase {
 	 *
 	 * @param string[] $slugs Part slugs to enable.
 	 */
-	private function enable( array $slugs ) {
+	/**
+	 * Switch on the placements that need the given parts.
+	 *
+	 * A part has no switch of its own: it backs a placement, and is provided
+	 * exactly when that placement is on.
+	 *
+	 * @param string[] $parts Part slugs to make available.
+	 */
+	private function enable( array $parts ) {
+		$slugs = array();
+
+		foreach ( Traktivity_Placements::available() as $slug => $placement ) {
+			if ( 'part' === $placement['type'] && in_array( $placement['part'], $parts, true ) ) {
+				$slugs[] = $slug;
+			}
+		}
+
 		update_option( Traktivity_Templates::OPTION, array_fill_keys( $slugs, true ) );
 	}
 
@@ -129,8 +145,8 @@ class TemplatePartsTest extends WP_UnitTestCase {
 	 */
 	public function test_part_id_is_namespaced_to_the_theme() {
 		$this->assertSame(
-			get_stylesheet() . '//traktivity-watch-stats',
-			Traktivity_Templates::part_id( 'traktivity-watch-stats' )
+			get_stylesheet() . '//traktivity-recent-compact',
+			Traktivity_Templates::part_id( 'traktivity-recent-compact' )
 		);
 	}
 
@@ -142,16 +158,16 @@ class TemplatePartsTest extends WP_UnitTestCase {
 			$this->markTestSkipped( 'No block theme available to switch to.' );
 		}
 
-		$this->enable( array( 'traktivity-watch-stats' ) );
+		$this->enable( array( 'traktivity-recent-compact' ) );
 
-		$id   = Traktivity_Templates::part_id( 'traktivity-watch-stats' );
+		$id   = Traktivity_Templates::part_id( 'traktivity-recent-compact' );
 		$part = Traktivity_Templates::provide_template_part( null, $id, 'wp_template_part' );
 
 		$this->assertInstanceOf( 'WP_Block_Template', $part );
-		$this->assertSame( 'traktivity-watch-stats', $part->slug );
+		$this->assertSame( 'traktivity-recent-compact', $part->slug );
 		$this->assertSame( 'plugin', $part->source );
 		$this->assertFalse( $part->has_theme_file );
-		$this->assertStringContainsString( 'traktivity/watch-stats', $part->content );
+		$this->assertStringContainsString( 'traktivity/event-card', $part->content );
 	}
 
 	/**
@@ -167,14 +183,13 @@ class TemplatePartsTest extends WP_UnitTestCase {
 			$this->markTestSkipped( 'No block theme available to switch to.' );
 		}
 
-		$this->enable( array( 'traktivity-watch-stats', 'traktivity-series-index' ) );
+		$this->enable( array( 'traktivity-recent-watches', 'traktivity-recent-compact' ) );
 
 		$listed = Traktivity_Templates::list_template_parts( array(), array(), 'wp_template_part' );
 		$slugs  = wp_list_pluck( $listed, 'slug' );
 
-		$this->assertContains( 'traktivity-watch-stats', $slugs );
-		$this->assertContains( 'traktivity-series-index', $slugs );
-		$this->assertNotContains( 'traktivity-recent-watches', $slugs, 'A part that is off should not be listed.' );
+		$this->assertContains( 'traktivity-recent-compact', $slugs );
+		$this->assertContains( 'traktivity-recent-watches', $slugs );
 	}
 
 	/**
@@ -188,16 +203,16 @@ class TemplatePartsTest extends WP_UnitTestCase {
 			$this->markTestSkipped( 'No block theme available to switch to.' );
 		}
 
-		$this->enable( array( 'traktivity-watch-stats' ) );
+		$this->enable( array( 'traktivity-recent-compact' ) );
 
 		$saved         = new WP_Block_Template();
-		$saved->slug   = 'traktivity-watch-stats';
+		$saved->slug   = 'traktivity-recent-compact';
 		$saved->source = 'custom';
 
 		$listed = Traktivity_Templates::list_template_parts( array( $saved ), array(), 'wp_template_part' );
 		$slugs  = wp_list_pluck( $listed, 'slug' );
 
-		$this->assertSame( 1, count( array_keys( $slugs, 'traktivity-watch-stats', true ) ) );
+		$this->assertSame( 1, count( array_keys( $slugs, 'traktivity-recent-compact', true ) ) );
 		$this->assertSame( 'custom', $listed[0]->source );
 	}
 
@@ -209,22 +224,22 @@ class TemplatePartsTest extends WP_UnitTestCase {
 			$this->markTestSkipped( 'No block theme available to switch to.' );
 		}
 
-		$this->enable( array( 'traktivity-watch-stats', 'traktivity-series-index' ) );
+		$this->enable( array( 'traktivity-recent-watches', 'traktivity-recent-compact' ) );
 
 		$listed = Traktivity_Templates::list_template_parts(
 			array(),
-			array( 'slug__in' => array( 'traktivity-series-index' ) ),
+			array( 'slug__in' => array( 'traktivity-recent-compact' ) ),
 			'wp_template_part'
 		);
 
-		$this->assertSame( array( 'traktivity-series-index' ), wp_list_pluck( $listed, 'slug' ) );
+		$this->assertSame( array( 'traktivity-recent-compact' ), wp_list_pluck( $listed, 'slug' ) );
 	}
 
 	/**
 	 * Whole templates and classic themes are left alone.
 	 */
 	public function test_listing_leaves_other_requests_alone() {
-		$this->enable( array( 'traktivity-watch-stats' ) );
+		$this->enable( array( 'traktivity-recent-compact' ) );
 
 		$this->assertSame( array(), Traktivity_Templates::list_template_parts( array(), array(), 'wp_template' ) );
 
@@ -246,7 +261,7 @@ class TemplatePartsTest extends WP_UnitTestCase {
 	 * A part that is switched off is not provided.
 	 */
 	public function test_disabled_part_is_not_provided() {
-		$id = Traktivity_Templates::part_id( 'traktivity-watch-stats' );
+		$id = Traktivity_Templates::part_id( 'traktivity-recent-compact' );
 
 		$this->assertNull( Traktivity_Templates::provide_template_part( null, $id, 'wp_template_part' ) );
 	}
@@ -258,16 +273,16 @@ class TemplatePartsTest extends WP_UnitTestCase {
 	 * the filter is handed a template and hands it straight back.
 	 */
 	public function test_an_existing_template_wins() {
-		$this->enable( array( 'traktivity-watch-stats' ) );
+		$this->enable( array( 'traktivity-recent-compact' ) );
 
 		$existing          = new WP_Block_Template();
-		$existing->slug    = 'traktivity-watch-stats';
+		$existing->slug    = 'traktivity-recent-compact';
 		$existing->source  = 'custom';
 		$existing->content = 'Edited by the site owner.';
 
 		$provided = Traktivity_Templates::provide_template_part(
 			$existing,
-			Traktivity_Templates::part_id( 'traktivity-watch-stats' ),
+			Traktivity_Templates::part_id( 'traktivity-recent-compact' ),
 			'wp_template_part'
 		);
 
@@ -279,7 +294,7 @@ class TemplatePartsTest extends WP_UnitTestCase {
 	 * An unrelated ID is left alone.
 	 */
 	public function test_other_ids_are_left_alone() {
-		$this->enable( array( 'traktivity-watch-stats' ) );
+		$this->enable( array( 'traktivity-recent-compact' ) );
 
 		$this->assertNull(
 			Traktivity_Templates::provide_template_part( null, get_stylesheet() . '//header', 'wp_template_part' )
@@ -290,12 +305,12 @@ class TemplatePartsTest extends WP_UnitTestCase {
 	 * A whole template asking for the same ID is left alone.
 	 */
 	public function test_whole_templates_are_left_alone() {
-		$this->enable( array( 'traktivity-watch-stats' ) );
+		$this->enable( array( 'traktivity-recent-compact' ) );
 
 		$this->assertNull(
 			Traktivity_Templates::provide_template_part(
 				null,
-				Traktivity_Templates::part_id( 'traktivity-watch-stats' ),
+				Traktivity_Templates::part_id( 'traktivity-recent-compact' ),
 				'wp_template'
 			)
 		);
@@ -305,12 +320,12 @@ class TemplatePartsTest extends WP_UnitTestCase {
 	 * Nothing is provided on a classic theme.
 	 */
 	public function test_nothing_is_provided_on_a_classic_theme() {
-		$this->enable( array( 'traktivity-watch-stats' ) );
+		$this->enable( array( 'traktivity-recent-compact' ) );
 
 		add_filter( 'wp_is_block_theme', '__return_false' );
 		$part = Traktivity_Templates::provide_template_part(
 			null,
-			Traktivity_Templates::part_id( 'traktivity-watch-stats' ),
+			Traktivity_Templates::part_id( 'traktivity-recent-compact' ),
 			'wp_template_part'
 		);
 		remove_filter( 'wp_is_block_theme', '__return_false' );

--- a/tests/php/TemplateSettingsRestTest.php
+++ b/tests/php/TemplateSettingsRestTest.php
@@ -90,7 +90,7 @@ class TemplateSettingsRestTest extends WP_UnitTestCase {
 		$slugs = wp_list_pluck( $data['templates'], 'slug' );
 
 		$this->assertContains( 'single-traktivity_event', $slugs );
-		$this->assertContains( 'traktivity-watch-stats', $slugs );
+		$this->assertContains( 'traktivity-totals-on-archive', $slugs );
 
 		foreach ( $data['templates'] as $template ) {
 			$this->assertFalse( $template['enabled'], "{$template['slug']} is on by default." );
@@ -106,7 +106,7 @@ class TemplateSettingsRestTest extends WP_UnitTestCase {
 		$types = wp_list_pluck( $this->request( 'GET' )->get_data()['templates'], 'type', 'slug' );
 
 		$this->assertSame( 'wp_template', $types['single-traktivity_event'] );
-		$this->assertSame( 'wp_template_part', $types['traktivity-watch-stats'] );
+		$this->assertSame( 'placement', $types['traktivity-totals-on-archive'] );
 	}
 
 	/**
@@ -194,6 +194,6 @@ class TemplateSettingsRestTest extends WP_UnitTestCase {
 
 		$this->assertArrayHasKey( 'single-traktivity_event', $flags );
 		$this->assertIsBool( $flags['single-traktivity_event'] );
-		$this->assertFalse( $flags['traktivity-watch-stats'], 'A part is never theme-provided.' );
+		$this->assertFalse( $flags['traktivity-totals-on-archive'], 'A placement is never theme-provided.' );
 	}
 }

--- a/traktivity.php
+++ b/traktivity.php
@@ -136,6 +136,7 @@ class Traktivity {
 		 */
 		require_once TRAKTIVITY__PLUGIN_DIR . 'blocks.traktivity.php';
 		require_once TRAKTIVITY__PLUGIN_DIR . 'templates.traktivity.php';
+		require_once TRAKTIVITY__PLUGIN_DIR . 'placements.traktivity.php';
 
 		// Settings panel.
 		if ( is_admin() ) {


### PR DESCRIPTION
Part of #683. Replaces the placement half of #699 after smoke testing showed it could not work.

## The problem

The parts shipped in #699 and #723 were editable, previewable, and impossible to
put on a page.

Core's Template Part block resolves a part two ways only, in
`wp-includes/blocks/template-part.php`: a `wp_template_part` post, then a theme
file under `parts/`. It never calls `get_block_template()`, so a part a plugin
answers for is invisible to it. Measured:

```
do_blocks( '<!-- wp:template-part {"slug":"traktivity-watch-stats",...} /-->' )
  without a wp_template_part post → 0 characters
  with one                        → 1100 characters
```

#698's card copy told people to place a part with that block. That could not
work, and no test caught it because the markup, the registration and the direct
edit link were all fine.

## What Jetpack does, and what this now does

Jetpack's subscribe placements never use that block either. They use two
mechanisms, and this uses the same two.

**Hooked blocks**, for a self-contained block anchored to another block in a
template — their post-end placement:

| Placement | Block | Anchor | Template |
|---|---|---|---|
| Totals above the archive | `traktivity/watch-stats` | before `core/query` | `archive-traktivity_event` |
| Last watched, above the archive | `traktivity/latest-watch` | before `core/query` | `archive-traktivity_event` |
| Series you watch most, after an entry | `traktivity/top-shows` | after `core/post-content` | `single-traktivity_event` |

The block lands in the template and the site owner can move or delete it in the
Site Editor, and that sticks. Classic themes have no templates to hook, so a
single-entry placement falls back to `the_content` — same fallback Jetpack uses.
An archive placement is skipped there rather than dropped somewhere arbitrary.

**`block_template_part()` at an action**, for the two parts whose markup is a
query loop rather than one block — their modal/overlay/floating-button approach:

| Placement | Part | Action |
|---|---|---|
| Recently watched, in the footer | `traktivity-recent-compact` | `wp_footer` |
| Recently watched, as a grid | `traktivity-recent-watches` | `wp_footer` |

A loop can't travel as a hooked block, which inserts a single registered block.

## What shrank

**Three parts are gone.** `traktivity-latest-watch`, `traktivity-watch-stats` and
`traktivity-series-index` were each one block wrapped in a heading, and a single
block is exactly what a hooked block places. They were an indirection with
nothing in it.

**A part no longer has its own switch.** It backs a placement, so it's provided
exactly when a placement using it is on, and that placement's card links to it
for editing. Two switches for one visible thing was confusing.

**The archive template loses its stats block.** The placement inserts one now,
and with both the page rendered two — caught in the browser, not by a test.

## Verified in the browser

On a single entry: the hooked Top Series block renders after the content (12
series), both footer parts render (13 cards), and the template's own title and
details are untouched. On the archive: one stats band, one hero, then the grid of
24.

## Testing

PHPUnit 283 passing, 624 assertions. Jest 55 passing. `composer run lint` and
`analyse` clean, build and package check pass.

New `PlacementsTest` covers: every placement naming a block or part that exists,
nothing on by default, a block hooked against the right anchor, a placement
staying out of the wrong template/anchor/position, a disabled placement hooking
nothing, a part rendering at its action, the classic-theme `the_content`
fallback, an archive placement skipped on a classic theme, every placement being
described, and placements sharing the templates option.
