### PR TITLE
Work through the review comments left on the merged pull requests

### DIFF
--- a/helpers.traktivity.php
+++ b/helpers.traktivity.php
@@ -204,24 +204,33 @@ function traktivity_get_event_title( int $post_id, bool $show_name = true ): str
 	 * episode code worth printing, so each part is dropped on its own rather
 	 * than the whole thing falling back to the bare episode name.
 	 */
-	$prefix = array();
+	$show = $show_name ? $event['show_name'] : '';
+	$code = $event['episode_code'];
 
-	if ( $show_name && '' !== $event['show_name'] ) {
-		$prefix[] = $event['show_name'];
+	/*
+	 * The two go through their own string rather than being joined with a
+	 * hard-coded space, so a translator can reorder them or change what sits
+	 * between them. Several languages want neither a space nor this order.
+	 */
+	if ( '' !== $show && '' !== $code ) {
+		$prefix = sprintf(
+			/* translators: 1: show name. 2: episode code, e.g. "S3E2". */
+			_x( '%1$s %2$s', 'Show name followed by episode code', 'traktivity' ),
+			$show,
+			$code
+		);
+	} else {
+		$prefix = '' !== $show ? $show : $code;
 	}
 
-	if ( '' !== $event['episode_code'] ) {
-		$prefix[] = $event['episode_code'];
-	}
-
-	if ( empty( $prefix ) ) {
+	if ( '' === $prefix ) {
 		return $event['title'];
 	}
 
 	$title = sprintf(
-		/* translators: 1: show name and/or episode code, e.g. "Some Show: S3E2". 2: episode title. */
+		/* translators: 1: show name and episode code, e.g. "Some Show S3E2". 2: episode title. */
 		_x( '%1$s: %2$s', 'Composed title for one watched episode', 'traktivity' ),
-		implode( ' ', $prefix ),
+		$prefix,
 		$event['title']
 	);
 
@@ -241,16 +250,20 @@ function traktivity_get_event_title( int $post_id, bool $show_name = true ): str
 }
 
 /**
- * Build one external reference.
+ * Pair a service with the label it is shown under.
  *
- * Shared by the event and show link builders so a URL template lives in one
- * place. IDs come from a third-party API, so they are encoded on the way into
- * a URL whatever they turn out to contain.
+ * The URLs are built by the callers, since each service takes a different path
+ * and a different ID. What is shared here is the label table and the two-key
+ * shape every reference comes back in, so a service is named the same way
+ * whether it was reached from an event or from a show.
+ *
+ * Callers encode the ID into the URL before calling this; nothing here
+ * inspects what a URL contains.
  *
  * @since 3.1.0
  *
  * @param string $service Service key: 'trakt', 'imdb' or 'tmdb'.
- * @param string $url     Full URL.
+ * @param string $url     Full URL, already built and encoded by the caller.
  *
  * @return array{label: string, url: string} One reference.
  */

--- a/helpers.traktivity.php
+++ b/helpers.traktivity.php
@@ -67,14 +67,23 @@ function traktivity_empty_event_context(): array {
  *
  * @return WP_Term|null First term, or null when there is none.
  */
-function traktivity_first_term( int $post_id, string $taxonomy ) {
+function traktivity_first_term( int $post_id, string $taxonomy ): ?WP_Term {
 	$terms = get_the_terms( $post_id, $taxonomy );
 
 	if ( is_wp_error( $terms ) || empty( $terms ) ) {
 		return null;
 	}
 
-	return $terms[0];
+	/*
+	 * reset() rather than $terms[0]. get_the_terms() hands its array through a
+	 * filter before returning, and anything narrowing it with array_filter()
+	 * keeps the original keys, so index 0 is not guaranteed to be there.
+	 * Anything that is not a term counts as no term, rather than reaching a
+	 * caller that reads ->name off it.
+	 */
+	$term = reset( $terms );
+
+	return $term instanceof WP_Term ? $term : null;
 }
 
 /**
@@ -153,7 +162,15 @@ function traktivity_get_event( int $post_id ): array {
 	 * @param array $context Event context.
 	 * @param int   $post_id Event post ID.
 	 */
-	return (array) apply_filters( 'traktivity_event_context', $context, $post_id );
+	$traktivity_filtered = apply_filters( 'traktivity_event_context', $context, $post_id );
+
+	/*
+	 * A filter returning something other than an array is ignored rather than
+	 * cast: (array) null is empty and (array) 'x' is a one-item list, and
+	 * either leaves callers with a context missing every documented key, which
+	 * they read without checking.
+	 */
+	return is_array( $traktivity_filtered ) ? $traktivity_filtered : $context;
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "traktivity",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "traktivity",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "GPL-2.0+",
       "devDependencies": {
         "@testing-library/jest-dom": "^7.0.1",

--- a/src/blocks/latest-watch/render.php
+++ b/src/blocks/latest-watch/render.php
@@ -103,9 +103,21 @@ $traktivity_wrapper = get_block_wrapper_attributes( array( 'class' => 'traktivit
 			<p class="traktivity-hero__kicker"><?php echo esc_html( $traktivity_kicker ); ?></p>
 		<?php endif; ?>
 
-		<?php if ( '' !== $traktivity_event['show_name'] && '' !== $traktivity_event['show_link'] ) : ?>
+		<?php if ( '' !== $traktivity_event['show_name'] ) : ?>
 			<p class="traktivity-hero__show">
-				<a href="<?php echo esc_url( $traktivity_event['show_link'] ); ?>"><?php echo esc_html( $traktivity_event['show_name'] ); ?></a>
+				<?php
+				/*
+				 * get_term_link() can fail, which empties show_link and leaves
+				 * the name behind. The name is the useful half, so it degrades
+				 * to plain text rather than disappearing, the way the event
+				 * card and the event title already do.
+				 */
+				?>
+				<?php if ( '' !== $traktivity_event['show_link'] ) : ?>
+					<a href="<?php echo esc_url( $traktivity_event['show_link'] ); ?>"><?php echo esc_html( $traktivity_event['show_name'] ); ?></a>
+				<?php else : ?>
+					<?php echo esc_html( $traktivity_event['show_name'] ); ?>
+				<?php endif; ?>
 			</p>
 		<?php endif; ?>
 

--- a/src/blocks/show-header/render.php
+++ b/src/blocks/show-header/render.php
@@ -30,21 +30,24 @@ $traktivity_network = traktivity_get_show_network( $traktivity_term->term_id );
 $traktivity_minutes = traktivity_get_show_runtime( $traktivity_term->term_id );
 $traktivity_runtime = $traktivity_minutes > 0 ? Traktivity_Stats::convert_time( $traktivity_minutes ) : '';
 
-/*
- * A 16:9 still from TMDb rather than the 2:3 poster the meta key suggests, so
- * it gets a landscape frame. Built here rather than inline below, so the
- * escaping annotation sits on one line the sniff can read.
- */
-$traktivity_art = Traktivity_Blocks::frame(
-	isset( $traktivity_poster['id'] ) ? (int) $traktivity_poster['id'] : 0,
-	$traktivity_term->name,
-	'landscape'
-);
-
 $traktivity_wrapper = get_block_wrapper_attributes( array( 'class' => 'traktivity-showhead' ) );
 ?>
 <header <?php echo $traktivity_wrapper; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Prepared by get_block_wrapper_attributes(). ?>>
 	<?php if ( ! isset( $attributes['showImage'] ) || $attributes['showImage'] ) : ?>
+		<?php
+		/*
+		 * A 16:9 still from TMDb rather than the 2:3 poster the meta key
+		 * suggests, so it gets a landscape frame. Built into a variable rather
+		 * than inline so the escaping annotation sits on one line the sniff can
+		 * read, and built in here so a header with its image turned off never
+		 * asks for the attachment.
+		 */
+		$traktivity_art = Traktivity_Blocks::frame(
+			isset( $traktivity_poster['id'] ) ? (int) $traktivity_poster['id'] : 0,
+			$traktivity_term->name,
+			'landscape'
+		);
+		?>
 		<div class="traktivity-showhead__art">
 			<?php echo $traktivity_art; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped in Traktivity_Blocks::frame(). ?>
 		</div>

--- a/src/components/templates/illustrations.js
+++ b/src/components/templates/illustrations.js
@@ -146,18 +146,23 @@ export function CompactList() {
  */
 export default function illustrationFor( slug ) {
 	switch ( slug ) {
+		// Templates.
 		case 'single-traktivity_event':
 			return <SingleEntry />;
 		case 'taxonomy-trakt_show':
 			return <SeriesArchive />;
-		case 'traktivity-latest-watch':
+
+		// Placements. Keyed on the placement, not on the block or part behind
+		// it, because that is what the settings screen puts on a card.
+		case 'traktivity-latest-on-archive':
 			return <Hero />;
-		case 'traktivity-watch-stats':
+		case 'traktivity-totals-on-archive':
 			return <StatsBand />;
-		case 'traktivity-series-index':
+		case 'traktivity-series-after-entry':
 			return <SeriesIndex />;
-		case 'traktivity-recent-compact':
+		case 'traktivity-recent-in-footer':
 			return <CompactList />;
+
 		default:
 			return <ArchiveGrid />;
 	}

--- a/stats.traktivity.php
+++ b/stats.traktivity.php
@@ -274,6 +274,13 @@ class Traktivity_Stats {
 		 */
 		$summary = (array) apply_filters( 'traktivity_stats_summary', $summary );
 
+		/*
+		 * A callback that drops a key would leave that hole in the cache for
+		 * half a day, and callers read these keys without checking they exist,
+		 * so anything missing goes back before the array is cached or returned.
+		 */
+		$summary = wp_parse_args( $summary, self::empty_summary() );
+
 		set_transient( self::SUMMARY_TRANSIENT, $summary, 12 * HOUR_IN_SECONDS );
 
 		return $summary;
@@ -326,10 +333,21 @@ class Traktivity_Stats {
 	 *
 	 * @since 3.1.0
 	 *
-	 * @param int $post_id Post ID.
+	 * @param int          $post_id Post ID.
+	 * @param WP_Post|null $post    Post object, as passed by both hooks.
 	 */
-	public static function flush_on_event_change( $post_id ) {
-		if ( 'traktivity_event' === get_post_type( $post_id ) ) {
+	public static function flush_on_event_change( $post_id, $post = null ) {
+		/*
+		 * deleted_post fires once the row is gone, so the object the hook
+		 * hands over is the only thing guaranteed to still describe it. Today
+		 * the lookup happens to work because core cleans the post cache after
+		 * the hook rather than before, which is not something to rely on. The
+		 * lookup stays as a fallback for anything firing this with one
+		 * argument.
+		 */
+		$type = $post instanceof WP_Post ? $post->post_type : get_post_type( $post_id );
+
+		if ( 'traktivity_event' === $type ) {
 			self::flush();
 		}
 	}
@@ -392,5 +410,5 @@ class Traktivity_Stats {
 	}
 }
 
-add_action( 'save_post', array( 'Traktivity_Stats', 'flush_on_event_change' ) );
-add_action( 'deleted_post', array( 'Traktivity_Stats', 'flush_on_event_change' ) );
+add_action( 'save_post', array( 'Traktivity_Stats', 'flush_on_event_change' ), 10, 2 );
+add_action( 'deleted_post', array( 'Traktivity_Stats', 'flush_on_event_change' ), 10, 2 );

--- a/templates.traktivity.php
+++ b/templates.traktivity.php
@@ -201,6 +201,30 @@ class Traktivity_Templates {
 	}
 
 	/**
+	 * Whether one of our templates is the one actually rendering.
+	 *
+	 * Switched on is not enough. The registry is only consulted by block
+	 * themes, and where the active theme carries the same slug its own
+	 * template wins over ours. In both cases the markup on screen belongs to
+	 * somebody else, and shaping the query would reorder a page we are not
+	 * drawing. The settings screen says as much on a theme-provided template,
+	 * so it had better be true.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param string $slug Template slug.
+	 *
+	 * @return bool
+	 */
+	private static function applies( string $slug ): bool {
+		if ( ! self::is_enabled( $slug ) || ! wp_is_block_theme() ) {
+			return false;
+		}
+
+		return ! in_array( $slug, self::theme_provided_slugs(), true );
+	}
+
+	/**
 	 * Shape the archive queries our templates inherit.
 	 *
 	 * Two things the templates cannot do for themselves.
@@ -226,7 +250,7 @@ class Traktivity_Templates {
 			return;
 		}
 
-		if ( $query->is_tax( 'trakt_show' ) && self::is_enabled( 'taxonomy-trakt_show' ) ) {
+		if ( $query->is_tax( 'trakt_show' ) && self::applies( 'taxonomy-trakt_show' ) ) {
 			/**
 			 * Filter the order a single series' archive reads in.
 			 *
@@ -242,14 +266,14 @@ class Traktivity_Templates {
 			return;
 		}
 
-		if ( $query->is_post_type_archive( 'traktivity_event' ) && self::is_enabled( 'archive-traktivity_event' ) ) {
+		if ( $query->is_post_type_archive( 'traktivity_event' ) && self::applies( 'archive-traktivity_event' ) ) {
 			$query->set( 'posts_per_page', self::posts_per_page( 'archive-traktivity_event', 24 ) );
 
 			return;
 		}
 
 		foreach ( array( 'trakt_genre', 'trakt_year', 'trakt_type' ) as $taxonomy ) {
-			if ( $query->is_tax( $taxonomy ) && self::is_enabled( 'taxonomy-' . $taxonomy ) ) {
+			if ( $query->is_tax( $taxonomy ) && self::applies( 'taxonomy-' . $taxonomy ) ) {
 				$query->set( 'posts_per_page', self::posts_per_page( 'taxonomy-' . $taxonomy, 24 ) );
 
 				return;
@@ -349,21 +373,21 @@ class Traktivity_Templates {
 	 * @return string[] Slugs the theme provides.
 	 */
 	public static function theme_provided_slugs(): array {
-		if ( ! wp_is_block_theme() || ! function_exists( 'get_block_templates' ) ) {
+		if ( ! wp_is_block_theme() ) {
 			return array();
 		}
 
-		$slugs = array_keys( self::available() );
-		$found = get_block_templates( array( 'slug__in' => $slugs ), 'wp_template' );
-		$ours  = array();
+		$slugs      = array_keys( self::available() );
+		$found      = get_block_templates( array( 'slug__in' => $slugs ), 'wp_template' );
+		$from_theme = array();
 
 		foreach ( $found as $template ) {
 			if ( 'theme' === $template->source ) {
-				$ours[] = $template->slug;
+				$from_theme[] = $template->slug;
 			}
 		}
 
-		return array_values( array_unique( $ours ) );
+		return array_values( array_unique( $from_theme ) );
 	}
 
 	/**
@@ -457,7 +481,7 @@ class Traktivity_Templates {
 	 *
 	 * @return WP_Block_Template|null Null when the markup is unreadable.
 	 */
-	private static function build_part( string $slug, array $part ) {
+	private static function build_part( string $slug, array $part ): ?WP_Block_Template {
 		$content = self::content( $part['file'] );
 
 		if ( '' === $content ) {

--- a/tests/js/illustrations.test.js
+++ b/tests/js/illustrations.test.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import illustrationFor from '../../src/components/templates/illustrations';
+
+/**
+ * Every slug the settings screen can put on a card.
+ *
+ * Kept in step with Traktivity_Templates::available() and
+ * Traktivity_Placements::available() by hand, because the wireframes are
+ * chosen in JavaScript from slugs decided in PHP. When the parts shrank, four
+ * cases here went unreachable and every placement quietly fell through to the
+ * generic grid; nothing caught it, because an unused exported component is not
+ * a lint error.
+ */
+const TEMPLATE_SLUGS = [
+	'single-traktivity_event',
+	'archive-traktivity_event',
+	'taxonomy-trakt_show',
+	'taxonomy-trakt_genre',
+	'taxonomy-trakt_year',
+	'taxonomy-trakt_type',
+];
+
+const PLACEMENT_SLUGS = [
+	'traktivity-totals-on-archive',
+	'traktivity-latest-on-archive',
+	'traktivity-series-after-entry',
+	'traktivity-recent-in-footer',
+	'traktivity-recent-after-archive',
+];
+
+/**
+ * Render a wireframe and describe its shapes, so two can be told apart.
+ *
+ * @param {string} slug Template or placement slug.
+ * @return {string} A signature for the shapes drawn.
+ */
+function signature( slug ) {
+	const { container } = render( illustrationFor( slug ) );
+
+	return [ ...container.querySelectorAll( 'rect' ) ]
+		.map( ( r ) => `${ r.getAttribute( 'x' ) },${ r.getAttribute( 'y' ) }` )
+		.join( '|' );
+}
+
+describe( 'illustrationFor', () => {
+	it.each( [ ...TEMPLATE_SLUGS, ...PLACEMENT_SLUGS ] )(
+		'draws something for %s',
+		( slug ) => {
+			expect( signature( slug ) ).not.toBe( '' );
+		}
+	);
+
+	it( 'gives each placement its own wireframe', () => {
+		const drawn = PLACEMENT_SLUGS.map( signature );
+
+		// Four of the five are distinct; the recent-watches grid deliberately
+		// reuses the archive wireframe, which is what it looks like.
+		expect( new Set( drawn ).size ).toBeGreaterThanOrEqual( 4 );
+	} );
+
+	it( 'falls back rather than rendering nothing for an unknown slug', () => {
+		expect( signature( 'something-that-does-not-exist' ) ).not.toBe( '' );
+	} );
+} );

--- a/tests/package/verify-package.mjs
+++ b/tests/package/verify-package.mjs
@@ -103,21 +103,32 @@ for ( const required of [
 	 * never both, so one of these disappearing is the signal that the entry
 	 * list in webpack.config.js needs looking at.
 	 */
+	/*
+	 * Every block.json names its own style-index.css, so a block shipped
+	 * without one registers a handle pointing at nothing and renders unstyled
+	 * rather than failing loudly.
+	 */
 	'build/blocks/event-card/block.json',
 	'build/blocks/event-card/render.php',
 	'build/blocks/event-card/style-index.css',
 	'build/blocks/event-title/block.json',
 	'build/blocks/event-title/render.php',
+	'build/blocks/event-title/style-index.css',
 	'build/blocks/event-details/block.json',
 	'build/blocks/event-details/render.php',
+	'build/blocks/event-details/style-index.css',
 	'build/blocks/watch-stats/block.json',
 	'build/blocks/watch-stats/render.php',
+	'build/blocks/watch-stats/style-index.css',
 	'build/blocks/top-shows/block.json',
 	'build/blocks/top-shows/render.php',
+	'build/blocks/top-shows/style-index.css',
 	'build/blocks/latest-watch/block.json',
 	'build/blocks/latest-watch/render.php',
+	'build/blocks/latest-watch/style-index.css',
 	'build/blocks/show-header/block.json',
 	'build/blocks/show-header/render.php',
+	'build/blocks/show-header/style-index.css',
 	'templates/single-traktivity_event.html',
 	'templates/archive-traktivity_event.html',
 	'templates/taxonomy-trakt_show.html',

--- a/tests/package/verify-package.mjs
+++ b/tests/package/verify-package.mjs
@@ -80,12 +80,6 @@ check(
 		leaked.length ? `: ${ leaked.join( ', ' ) }` : ''
 	}`
 );
-check(
-	leaked.length === 0,
-	`no development files ship${
-		leaked.length ? `: ${ leaked.join( ', ' ) }` : ''
-	}`
-);
 
 // The files WordPress needs to boot the plugin and its dashboard.
 for ( const required of [

--- a/tests/php/BlockTemplatesTest.php
+++ b/tests/php/BlockTemplatesTest.php
@@ -11,11 +11,49 @@
 class BlockTemplatesTest extends WP_UnitTestCase {
 
 	/**
+	 * Theme active before a test switched it.
+	 *
+	 * @var string
+	 */
+	private $previous_theme = '';
+
+	/**
 	 * Start each test with nothing switched on.
 	 */
 	public function set_up() {
 		parent::set_up();
 		delete_option( Traktivity_Templates::OPTION );
+	}
+
+	/**
+	 * Put any switched theme back.
+	 */
+	public function tear_down() {
+		if ( '' !== $this->previous_theme ) {
+			switch_theme( $this->previous_theme );
+			$this->previous_theme = '';
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Switch to a block theme.
+	 *
+	 * Query shaping only happens where our templates can actually render, so
+	 * anything testing it has to be on a theme that consults the registry.
+	 *
+	 * @return bool Whether a block theme was available.
+	 */
+	private function use_block_theme() {
+		if ( ! wp_get_theme( 'twentytwentyfour' )->exists() ) {
+			return false;
+		}
+
+		$this->previous_theme = get_stylesheet();
+		switch_theme( 'twentytwentyfour' );
+
+		return true;
 	}
 
 	/**
@@ -145,47 +183,31 @@ class BlockTemplatesTest extends WP_UnitTestCase {
 	 * a bundled block theme for the duration.
 	 */
 	public function test_enabled_template_registers() {
-		$theme = wp_get_theme( 'twentytwentyfour' );
-
-		if ( ! $theme->exists() ) {
+		if ( ! $this->use_block_theme() ) {
 			$this->markTestSkipped( 'No block theme available to switch to.' );
 		}
-
-		$previous = get_stylesheet();
-		switch_theme( 'twentytwentyfour' );
 
 		$this->enable( array( 'single-traktivity_event' ) );
 		Traktivity_Templates::register_templates();
 
 		$registered = get_block_templates( array( 'slug__in' => array( 'single-traktivity_event' ) ) );
-		$slugs      = wp_list_pluck( $registered, 'slug' );
 
-		switch_theme( $previous );
-
-		$this->assertContains( 'single-traktivity_event', $slugs );
+		$this->assertContains( 'single-traktivity_event', wp_list_pluck( $registered, 'slug' ) );
 	}
 
 	/**
 	 * A template that is off does not register.
 	 */
 	public function test_disabled_template_does_not_register() {
-		$theme = wp_get_theme( 'twentytwentyfour' );
-
-		if ( ! $theme->exists() ) {
+		if ( ! $this->use_block_theme() ) {
 			$this->markTestSkipped( 'No block theme available to switch to.' );
 		}
-
-		$previous = get_stylesheet();
-		switch_theme( 'twentytwentyfour' );
 
 		Traktivity_Templates::register_templates();
 
 		$registered = get_block_templates( array( 'slug__in' => array( 'archive-traktivity_event' ) ) );
-		$slugs      = wp_list_pluck( $registered, 'slug' );
 
-		switch_theme( $previous );
-
-		$this->assertNotContains( 'archive-traktivity_event', $slugs );
+		$this->assertNotContains( 'archive-traktivity_event', wp_list_pluck( $registered, 'slug' ) );
 	}
 
 	/**
@@ -236,6 +258,10 @@ class BlockTemplatesTest extends WP_UnitTestCase {
 	 * round for it.
 	 */
 	public function test_series_archive_reads_oldest_first() {
+		if ( ! $this->use_block_theme() ) {
+			$this->markTestSkipped( 'No block theme available to switch to.' );
+		}
+
 		$this->enable( array( 'taxonomy-trakt_show' ) );
 
 		$query    = $this->series_archive_query( 'some-series' );
@@ -271,6 +297,10 @@ class BlockTemplatesTest extends WP_UnitTestCase {
 	 * two and a half rows tall.
 	 */
 	public function test_archive_page_size_follows_the_template() {
+		if ( ! $this->use_block_theme() ) {
+			$this->markTestSkipped( 'No block theme available to switch to.' );
+		}
+
 		$this->enable( array( 'archive-traktivity_event', 'taxonomy-trakt_show' ) );
 
 		$archive             = new WP_Query();
@@ -295,6 +325,10 @@ class BlockTemplatesTest extends WP_UnitTestCase {
 	 * The page size is filterable, so a site can hand control back to itself.
 	 */
 	public function test_archive_page_size_is_filterable() {
+		if ( ! $this->use_block_theme() ) {
+			$this->markTestSkipped( 'No block theme available to switch to.' );
+		}
+
 		$this->enable( array( 'archive-traktivity_event' ) );
 
 		add_filter( 'traktivity_archive_posts_per_page', static fn() => 5 );
@@ -327,6 +361,39 @@ class BlockTemplatesTest extends WP_UnitTestCase {
 		$GLOBALS['wp_the_query'] = $previous;
 
 		$this->assertSame( '', $archive->get( 'posts_per_page' ) );
+	}
+
+	/**
+	 * A classic theme's archives are left exactly as the theme wrote them.
+	 *
+	 * Our templates are never consulted there, so reordering the query or
+	 * changing its page size would reshape a page somebody else is drawing.
+	 */
+	public function test_classic_themes_are_left_alone() {
+		$this->enable( array( 'archive-traktivity_event', 'taxonomy-trakt_show' ) );
+
+		$archive                       = new WP_Query();
+		$archive->is_archive           = true;
+		$archive->is_post_type_archive = true;
+		$archive->set( 'post_type', 'traktivity_event' );
+
+		$series   = $this->series_archive_query( 'classic-series' );
+		$previous = $GLOBALS['wp_the_query'];
+
+		add_filter( 'wp_is_block_theme', '__return_false' );
+
+		$GLOBALS['wp_the_query'] = $archive;
+		Traktivity_Templates::shape_archive_query( $archive );
+
+		$GLOBALS['wp_the_query'] = $series;
+		Traktivity_Templates::shape_archive_query( $series );
+
+		remove_filter( 'wp_is_block_theme', '__return_false' );
+		$GLOBALS['wp_the_query'] = $previous;
+
+		$this->assertSame( '', $archive->get( 'posts_per_page' ) );
+		$this->assertSame( '', $series->get( 'posts_per_page' ) );
+		$this->assertSame( '', $series->get( 'order' ) );
 	}
 
 	/**

--- a/tests/php/ContractsTest.php
+++ b/tests/php/ContractsTest.php
@@ -109,9 +109,15 @@ class ContractsTest extends WP_UnitTestCase {
 	public function test_event_accessor_returns_the_full_shape() {
 		$post_id = $this->factory->post->create();
 
+		$expected = array_keys( traktivity_empty_event_context() );
+		$actual   = array_keys( traktivity_get_event( $post_id ) );
+
+		sort( $expected );
+		sort( $actual );
+
 		$this->assertSame(
-			array_keys( traktivity_empty_event_context() ),
-			array_keys( traktivity_get_event( $post_id ) ),
+			$expected,
+			$actual,
 			'traktivity_get_event() returned a different shape to the documented one.'
 		);
 	}
@@ -135,18 +141,28 @@ class ContractsTest extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_link_accessors
 	 *
-	 * @param string $accessor Function name.
+	 * @param string   $accessor Function name.
+	 * @param callable $subject  Builds something for the accessor to describe.
 	 */
-	public function test_link_accessor_shape( $accessor ) {
-		$links = $accessor( 0 );
+	public function test_link_accessor_shape( $accessor, $subject ) {
+		$links = $accessor( $subject() );
 
-		$this->assertIsArray( $links, "{$accessor}() should return an array." );
+		/*
+		 * Built against a real event and a real show. Passing 0 returns an
+		 * empty array from both, so the loop below never ran and the shape it
+		 * describes went unchecked.
+		 */
+		$this->assertNotEmpty( $links, "{$accessor}() found nothing to describe." );
 
 		foreach ( $links as $service => $link ) {
 			$this->assertIsString( $service, 'Links are keyed by service name.' );
+
+			$keys = array_keys( $link );
+			sort( $keys );
+
 			$this->assertSame(
 				array( 'label', 'url' ),
-				array_keys( $link ),
+				$keys,
 				"{$accessor}() entries carry a label and a url."
 			);
 		}
@@ -155,12 +171,32 @@ class ContractsTest extends WP_UnitTestCase {
 	/**
 	 * The accessors that return external links.
 	 *
-	 * @return array<string, array{string}>
+	 * Each case carries a callable that builds something for the accessor to
+	 * describe, since a data provider runs before the test case exists and
+	 * cannot make posts or terms itself.
+	 *
+	 * @return array<string, array{string, callable}>
 	 */
 	public function data_link_accessors() {
 		return array(
-			'event links' => array( 'traktivity_get_event_links' ),
-			'show links'  => array( 'traktivity_get_show_links' ),
+			'event links' => array(
+				'traktivity_get_event_links',
+				static function () {
+					$post_id = self::factory()->post->create( array( 'post_type' => 'traktivity_event' ) );
+					update_post_meta( $post_id, 'trakt_movie_id', 4242 );
+
+					return $post_id;
+				},
+			),
+			'show links'  => array(
+				'traktivity_get_show_links',
+				static function () {
+					$term = self::factory()->term->create_and_get( array( 'taxonomy' => 'trakt_show' ) );
+					update_term_meta( $term->term_id, 'show_external_ids', array( 'trakt' => 4242 ) );
+
+					return $term->term_id;
+				},
+			),
 		);
 	}
 

--- a/tests/php/EventDetailsBlockTest.php
+++ b/tests/php/EventDetailsBlockTest.php
@@ -184,7 +184,7 @@ class EventDetailsBlockTest extends WP_UnitTestCase {
 	/**
 	 * A runtime of one minute is singular.
 	 */
-	public function test_runtime_is_pluralised() {
+	public function test_runtime_of_one_minute_is_singular() {
 		$post_id = $this->make_event(
 			array(
 				'trakt_show_id' => 6,

--- a/tests/php/TemplateSettingsRestTest.php
+++ b/tests/php/TemplateSettingsRestTest.php
@@ -20,7 +20,7 @@ class TemplateSettingsRestTest extends WP_UnitTestCase {
 
 		global $wp_rest_server;
 		$wp_rest_server = new WP_REST_Server();
-		do_action( 'rest_api_init' );
+		do_action( 'rest_api_init', $wp_rest_server );
 	}
 
 	/**

--- a/tests/php/WatchStatsBlockTest.php
+++ b/tests/php/WatchStatsBlockTest.php
@@ -91,9 +91,11 @@ class WatchStatsBlockTest extends WP_UnitTestCase {
 		$html = $this->render();
 
 		$this->assertStringContainsString( 'traktivity-stats', $html );
+		$this->assertStringContainsString( 'Hours', $html );
 		$this->assertStringContainsString( 'Entries', $html );
 		$this->assertStringContainsString( 'Episodes', $html );
 		$this->assertStringContainsString( 'Films', $html );
+		$this->assertStringContainsString( 'Series', $html );
 		$this->assertStringContainsString( 'Logging since', $html );
 	}
 
@@ -108,6 +110,16 @@ class WatchStatsBlockTest extends WP_UnitTestCase {
 		$html = $this->render( array( 'figures' => array( 'films', 'entries' ) ) );
 
 		$this->assertStringNotContainsString( 'Episodes', $html );
+
+		/*
+		 * Both labels have to be there before their positions mean anything: a
+		 * missing one makes strpos() return false, which compares as earlier
+		 * than every real position and would pass the order check below on a
+		 * block that rendered nothing.
+		 */
+		$this->assertStringContainsString( 'Films', $html );
+		$this->assertStringContainsString( 'Entries', $html );
+
 		$this->assertLessThan(
 			strpos( $html, 'Entries' ),
 			strpos( $html, 'Films' ),

--- a/widgets/list-events.php
+++ b/widgets/list-events.php
@@ -350,10 +350,10 @@ class Traktivity_List_Widget extends WP_Widget {
 		$event_title .= '<div class="episode-details">';
 
 		$event_title .= sprintf(
-			/* translators: additional informaton about each episode displayed in the widget listing recent watched TV shows. */
+			/* translators: 1: link to the show. 2: season number. 3: episode number. */
 			_x(
 				'%1$s, season %2$d, episode %3$d',
-				'1: Episode title. 2. Show title. 3. Season number. 4. Episode number.',
+				'Episode details listed under each event in the recent watches widget',
 				'traktivity'
 			),
 			$show_title,


### PR DESCRIPTION
Part of #683.

Automated review left 32 inline comments across this milestone's pull requests and
I read none of them. This works through the backlog. Each was verified against the
code rather than applied on sight, which turned out to matter.

## Two were wrong, and following them would have made things worse

**`auth_callback => '__return_false'` on the show term meta** was said to block REST
reads entirely and defeat the point of #687. It doesn't. Verified against core and
against a live dispatch:

```
GET /wp/v2/trakt_show/154, logged out    → 200, all four meta keys present
POST /wp/v2/trakt_show/154, as admin     → 403 rest_cannot_update, value unchanged
```

`WP_REST_Meta_Fields::get_value()` never consults a capability; the check only
appears in the update and delete paths. So the current code already delivers exactly
"readable but not writable". Removing it would be a regression: `register_meta()`
falls back to `is_protected_meta()` when `auth_callback` is empty, and since none of
these keys start with `_`, anyone with `manage_categories` could then overwrite
sync-owned data over REST.

**The ordering assertion in `WatchStatsBlockTest`** was said to be reversed.
`assertLessThan( $expected, $actual )` asserts `$actual < $expected`, so the test
says Films appears before Entries — which is what the block does. The review read
the arguments in the opposite order.

It did deserve a guard, though, just not the one suggested: a label that vanished
entirely makes `strpos()` return `false`, and `false < 42` is `true`, so the check
would have passed on a block rendering nothing.

## The real bugs

**Query shaping ran where our templates never render.** `shape_archive_query()`
gated only on the option, so a classic theme's archives were being reordered and
repaginated even though the registry is never consulted there — and so were archives
on any theme carrying the same slug, whose template wins over ours. The settings
screen says in that second case that switching ours on "will not change anything",
which wasn't true. A new `applies()` predicate checks all three conditions.

Three existing tests were passing only because the shaping ignored the theme. They
now switch to a block theme, and there's a new test asserting a classic theme is left
exactly as its author wrote it.

**`traktivity_first_term()` read `$terms[0]`.** `get_the_terms()` passes its array
through a filter before returning, and anything narrowing it with `array_filter()`
preserves keys — so index 0 isn't guaranteed. Now uses `reset()`, with an
`instanceof` guard that also makes the new `?WP_Term` return type safe.

**Two filters could void the contracts their own docblocks describe.** A
`traktivity_event_context` callback returning a non-array was cast, losing every
documented key that callers read without checking. A `traktivity_stats_summary`
callback dropping a key had that hole cached for half a day.

**`flush_on_event_change()` re-looked-up the post type on `deleted_post`.** That
works today only because core calls `clean_post_cache()` *after* firing the hook. The
row is already gone, so the object the hook passes is the only reliable description —
and both hooks now register with `accepted_args` of 2 so it actually arrives.

**The hero dropped a series name it had** whenever `get_term_link()` failed, where
the event card and event title both fall back to plain text.

**A series header with its image off still fetched the attachment** and built the
markup before deciding not to print it.

**The package check required one block stylesheet out of seven**, so six could have
shipped unstyled. And `package-lock.json` still said 3.0.1.

## Testing

PHPUnit 285 passing, 632 assertions. Jest 55. `composer run lint` and `analyse`
clean, build, package check and JS lint pass.

## Going forward

I'll read the review on each PR before merging it, rather than after the fact. That
already caught a real regression on #724 — archive placements rendering at content
width above a wide grid.
