### PR TITLE
Stop the stats endpoint answering anyone who asks

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -104,6 +104,7 @@ Traktivity has always logged your watch history and done almost nothing with it.
 * Recount the total time watched when an entry is deleted. It used to only ever be added to, so deleting an entry left the total too high with no way to correct it.
 * Attach a season term to specials, which land in season 0. Nothing has ever recorded a season for them. Entries synced before this update keep their missing season; re-syncing does not revisit them.
 * Show the episode details in the Recently Watched widget on sites not running in English, where they were silently dropped.
+* Ask for the same permissions on the `traktivity/v1/stats` endpoint as on every other endpoint the plugin registers. It answered anyone who asked, so your watch totals were readable without logging in even on a site showing none of this. Anything of yours reading that endpoint now needs to authenticate.
 
 = 3.0.1 =
 Release date: September 3, 2026

--- a/rest.traktivity.php
+++ b/rest.traktivity.php
@@ -144,6 +144,12 @@ class Traktivity_Api {
 		/**
 		 * Traktivity Stats Info.
 		 *
+		 * Behind the same capability as the rest of the namespace. This route
+		 * hands back the traktivity_stats option as it stands, and it was
+		 * public only because '__return_true' was the quickest way to silence
+		 * the notice WordPress 5.5 started printing for a route with no
+		 * permission callback.
+		 *
 		 * @since 2.2.0
 		 */
 		register_rest_route(
@@ -152,7 +158,7 @@ class Traktivity_Api {
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_stats' ),
-				'permission_callback' => '__return_true',
+				'permission_callback' => array( $this, 'permissions_check' ),
 			)
 		);
 	}

--- a/tests/php/RestPermissionsTest.php
+++ b/tests/php/RestPermissionsTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Tests for who can reach the plugin's REST routes.
+ *
+ * @package Traktivity
+ */
+
+/**
+ * Every route in the namespace is an admin route.
+ *
+ * These endpoints exist to drive the dashboard, which is behind
+ * manage_options. Nothing here is part of the plugin's public surface: what a
+ * site publishes about its watch history is the blocks and the archives, which
+ * a site owner switches on deliberately.
+ */
+class RestPermissionsTest extends WP_UnitTestCase {
+
+	/**
+	 * Register the plugin's routes for each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		delete_option( 'traktivity_stats' );
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		do_action( 'rest_api_init', $wp_rest_server );
+	}
+
+	/**
+	 * Clean up.
+	 */
+	public function tear_down() {
+		delete_option( 'traktivity_stats' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Ask for the stats.
+	 *
+	 * @return WP_REST_Response
+	 */
+	private function get_stats() {
+		return rest_get_server()->dispatch( new WP_REST_Request( 'GET', '/traktivity/v1/stats' ) );
+	}
+
+	/**
+	 * No route answers a caller who has not proved anything.
+	 *
+	 * The stats route used to, because '__return_true' was the quickest way to
+	 * satisfy the permission callback WordPress 5.5 started insisting on. That
+	 * published the traktivity_stats option to anyone who asked for it, on
+	 * every site running the plugin, whether or not the site owner had
+	 * switched on anything that shows those figures.
+	 */
+	public function test_no_route_is_open_to_everyone() {
+		$routes = rest_get_server()->get_routes( 'traktivity/v1' );
+
+		$this->assertNotEmpty( $routes, 'The plugin registered no routes.' );
+
+		foreach ( $routes as $route => $handlers ) {
+			// The namespace index itself is core's, and is meant to be readable.
+			if ( '/traktivity/v1' === $route ) {
+				continue;
+			}
+
+			foreach ( $handlers as $handler ) {
+				/*
+				 * A route with no callback at all is worse than one that
+				 * returns true: WordPress lets the request through and only
+				 * grumbles about it in the log.
+				 */
+				$this->assertArrayHasKey(
+					'permission_callback',
+					$handler,
+					"Route $route checks nothing at all."
+				);
+
+				$this->assertNotSame(
+					'__return_true',
+					$handler['permission_callback'],
+					"Route $route is readable by anyone."
+				);
+			}
+		}
+	}
+
+	/**
+	 * A visitor cannot read the stats.
+	 */
+	public function test_stats_are_not_readable_by_a_visitor() {
+		wp_set_current_user( 0 );
+
+		$this->assertSame( 401, $this->get_stats()->get_status() );
+	}
+
+	/**
+	 * Neither can a logged-in user without the capability.
+	 */
+	public function test_stats_are_not_readable_by_a_subscriber() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$this->assertSame( 403, $this->get_stats()->get_status() );
+	}
+
+	/**
+	 * An administrator still gets them.
+	 */
+	public function test_stats_are_readable_by_an_administrator() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		update_option( 'traktivity_stats', array( 'total_time_watched' => 4242 ) );
+
+		$response = $this->get_stats();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array( 'total_time_watched' => 4242 ), $response->get_data() );
+	}
+}


### PR DESCRIPTION
## What it does

`GET /wp-json/traktivity/v1/stats` had `permission_callback => '__return_true'`, so it answered anyone and returned the `traktivity_stats` option as it stands. Logged out, against my dev site:

```
$ curl -s 'http://localhost:8888/?rest_route=/traktivity/v1/stats'
{"total_time_watched":49476}
```

It now goes through `permissions_check()`, the same `manage_options` gate as every other route in the namespace.

## Rationale

The open callback was never a decision. It came in with 8974345, a one-line commit called "Add missing parameter when registering stats route": WordPress 5.5 had started printing a notice for a route registered without a permission callback, and `__return_true` made the notice go away.

Two reasons to close it rather than leave it alone. Nothing reads the endpoint; the dashboard gets the same figure from the inline script `admin.traktivity.php` prints, no test touches it, and it isn't documented anywhere. And the callback hands back whatever the option holds rather than a shape it picked, so the next key written into `traktivity_stats` would have gone public without anyone deciding it should.

Of note, the severity is low. The event post type is public and so are its archives, so a patient visitor can work the figure out anyway. What made it worth fixing is that the endpoint served it even on a site with none of the display features switched on, which is the default.

It does break anything of yours that reads the endpoint anonymously. That is the one thing here that needs your call rather than mine, and it is in the 3.1.0 changelog.

## Testing

Same request, after:

```
$ curl -s 'http://localhost:8888/?rest_route=/traktivity/v1/stats'
{"code":"rest_forbidden","message":"Sorry, you are not allowed to do that.","data":{"status":401}}
```

An admin still gets the figures. `tests/php/RestPermissionsTest.php` covers a visitor, a subscriber and an admin, and sweeps the whole namespace rather than naming this one route, so an endpoint registered the same way later fails the suite. It also fails a handler registered with no permission callback at all, which WordPress waves through with only a log entry.

Three of the four tests fail on `feature/display-trakt-data` without the one-line change.

Full gate green: `composer run lint`, `composer run analyse`, `npm run test:php` (289 tests), `npm run test:unit` (68 tests), `npm run lint:js`, `npm run lint:css`, `npm run test:package`.
